### PR TITLE
feat(4): 장바구니 관리

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
@@ -107,4 +107,25 @@ public class ApiV1CartController {
         );
     }
 
+    // 자신의 장바구니 상품 삭제
+    @DeleteMapping("/{id}")
+    @Transactional
+    public RsData<Void> deleteCartItem(
+            @RequestBody @Valid AuthReqBody authReqBody,
+            @PathVariable(name = "id") Long itemId
+    ) {
+        User actor = userService.getUserByAuthToken(authReqBody.authToken());
+        User realActor = userService.findByEmail(actor.getEmail())
+                .orElseThrow(() -> new ServiceException("401", "인증 정보가 잘못되었습니다."));
+        Cart cart = cartService.getMyCart(realActor);
+
+        cartItemService.deleteCartItem(cart, itemId);
+
+        return new RsData<>(
+                "200-1",
+                "장바구니의 상품이 삭제되었습니다."
+        );
+    }
+
+
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
@@ -127,5 +127,20 @@ public class ApiV1CartController {
         );
     }
 
+    // 자산의 장바구니 상품 전체 삭제
+    @DeleteMapping()
+    @Transactional
+    public RsData<Void> deleteCart(@RequestBody @Valid AuthReqBody authReqBody) {
+        User actor = userService.getUserByAuthToken(authReqBody.authToken());
+        User realActor = userService.findByEmail(actor.getEmail())
+                .orElseThrow(() -> new ServiceException("401", "인증 정보가 잘못되었습니다."));
+        Cart cart = cartService.getMyCart(realActor);
 
+        cartService.deleteCart(cart);
+
+        return new RsData<>(
+                "200-1",
+                "장바구니에 담긴 모든 상품이 삭제되었습니다."
+        );
+    }
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
@@ -1,0 +1,56 @@
+package com.coffeebean.domain.cart.cart.controller;
+
+import com.coffeebean.domain.cart.cart.entity.Cart;
+import com.coffeebean.domain.cart.cart.service.CartService;
+import com.coffeebean.domain.cart.cartItem.service.CartItemService;
+import com.coffeebean.domain.user.user.enitity.User;
+import com.coffeebean.domain.user.user.service.UserService;
+import com.coffeebean.global.dto.RsData;
+import com.coffeebean.global.exception.ServiceException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/carts")
+public class ApiV1CartController {
+
+    private final CartService cartService;
+    private final CartItemService cartItemService;
+    private final UserService userService;
+
+    record AddItemReqBody(
+            Long id,
+            @NotNull(message = "상품 수량이 입력되지 않았습니다.")
+            @Min(value = 1, message = "잘못된 상품 수량입니다.")
+            Integer quantity,
+            @NotBlank(message = "인증 정보가 없습니다.")
+            String authToken
+    ) {
+    }
+
+    // 자신의 장바구니에 상품 추가
+    @PostMapping
+    public RsData<Void> addCartItemToCart(@RequestBody @Valid AddItemReqBody addItemReqBody) {
+
+        User actor = userService.getUserByAuthToken(addItemReqBody.authToken());
+        User realActor = userService.findByEmail(actor.getEmail())
+                .orElseThrow(() -> new ServiceException("401", "인증 정보가 잘못되었습니다."));
+        Cart cart = cartService.getMyCart(realActor);
+        cartItemService.addCartItem(cart, addItemReqBody.id(), addItemReqBody.quantity());
+
+        return new RsData<>(
+                "200-1",
+                "장바구니에 상품이 추가되었습니다."
+        );
+    }
+
+
+}

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartController.java
@@ -80,4 +80,31 @@ public class ApiV1CartController {
         );
     }
 
+    record CartItemModifyReqBody(
+            @NotNull(message = "상품 수량이 입력되지 않았습니다.")
+            @Min(value = 1, message = "잘못된 상품 수량입니다.")
+            int quantity,
+            @NotBlank(message = "인증 정보가 없습니다.")
+            String authToken
+    ) {
+    }
+
+    // 자신의 장바구니 상품 수량 변경
+    @PutMapping("/{id}")
+    @Transactional
+    public RsData<Void> modifyCartItem(@RequestBody @Valid CartItemModifyReqBody cartModifyReqBody, @PathVariable(name = "id") Long itemId) {
+
+        User actor = userService.getUserByAuthToken(cartModifyReqBody.authToken());
+        User realActor = userService.findByEmail(actor.getEmail())
+                .orElseThrow(() -> new ServiceException("401", "인증 정보가 잘못되었습니다."));
+        Cart cart = cartService.getMyCart(realActor);
+
+        cartItemService.modifyCartItem(cart, itemId, cartModifyReqBody.quantity());
+
+        return new RsData<>(
+                "200-1",
+                "장바구니의 상품 수량이 변경되었습니다."
+        );
+    }
+
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/dto/CartItemDto.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/dto/CartItemDto.java
@@ -1,0 +1,25 @@
+package com.coffeebean.domain.cart.cart.dto;
+
+import com.coffeebean.domain.cart.cartItem.entity.CartItem;
+import lombok.Getter;
+import org.springframework.lang.NonNull;
+
+@Getter
+public class CartItemDto {
+
+    @NonNull
+    private long id;
+
+    private int quantity;
+
+    private String name;
+
+    private int price;
+
+    public CartItemDto(CartItem cartItem) {
+        this.quantity = cartItem.getQuantity();
+        this.id = cartItem.getItem().getId();
+        this.name = cartItem.getItem().getName();
+        this.price = cartItem.getItem().getPrice();
+    }
+}

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/dto/CartListResponseDto.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/dto/CartListResponseDto.java
@@ -1,0 +1,12 @@
+package com.coffeebean.domain.cart.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CartListResponseDto {
+    private List<CartItemDto> items;
+}

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/entity/Cart.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/entity/Cart.java
@@ -1,22 +1,18 @@
 package com.coffeebean.domain.cart.cart.entity;
 
-import org.springframework.boot.autoconfigure.web.WebProperties;
+import com.coffeebean.domain.cart.cartItem.entity.CartItem;
+import jakarta.persistence.*;
 
 import com.coffeebean.domain.user.user.enitity.User;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,4 +29,12 @@ public class Cart {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
+
+	@Builder.Default
+	@OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<CartItem> cartItems = new ArrayList<>();
+
+	public void deleteAllCartItems() {
+		cartItems.clear();
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/repository/CartRepository.java
@@ -1,0 +1,13 @@
+package com.coffeebean.domain.cart.cart.repository;
+
+import com.coffeebean.domain.cart.cart.entity.Cart;
+import com.coffeebean.domain.user.user.enitity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    Optional<Cart> findByUser(User user);
+}

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/service/CartService.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/service/CartService.java
@@ -27,4 +27,9 @@ public class CartService {
         return opCart.get();
     }
 
+    @Transactional
+    public void deleteCart(Cart cart) {
+        cart.deleteAllCartItems();
+        cartRepository.save(cart);
+    }
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/service/CartService.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/service/CartService.java
@@ -1,0 +1,30 @@
+package com.coffeebean.domain.cart.cart.service;
+
+import com.coffeebean.domain.cart.cart.entity.Cart;
+import com.coffeebean.domain.cart.cart.repository.CartRepository;
+import com.coffeebean.domain.user.user.enitity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+
+    @Transactional
+    public Cart getMyCart(User actor) {
+        Optional<Cart> opCart = cartRepository.findByUser(actor);
+
+        // 사용자의 Cart가 존재하지 않는 경우 생성해 반환
+        if (opCart.isEmpty()) {
+            return cartRepository.save(Cart.builder().user(actor).build());
+        }
+
+        return opCart.get();
+    }
+
+}

--- a/backend/src/main/java/com/coffeebean/domain/cart/cartItem/entity/CartItem.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cartItem/entity/CartItem.java
@@ -10,11 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -28,12 +24,20 @@ public class CartItem {
 	private Long id; // PK
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "cart_id")
+	@JoinColumn(name = "cart_id", nullable = false)
 	private Cart cart;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "item_id")
+	@JoinColumn(name = "item_id", nullable = false)
 	private Item item;
 
 	private int quantity;    // 장바구니 상품 수량
+
+	public void updateQuantity(int quantity) {
+		this.quantity = quantity;
+	}
+
+	public void addQuantity(int quantity) {
+		this.quantity += quantity;
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cartItem/repository/CartItemRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cartItem/repository/CartItemRepository.java
@@ -1,0 +1,16 @@
+package com.coffeebean.domain.cart.cartItem.repository;
+
+import com.coffeebean.domain.cart.cart.entity.Cart;
+import com.coffeebean.domain.cart.cartItem.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    List<CartItem> findByCart(Cart cart);
+    Optional<CartItem> findByCartIdAndItemId(Long cartId, Long itemId);
+    Optional<CartItem> findByItemId(Long itemId);
+}

--- a/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
@@ -59,4 +59,11 @@ public class CartItemService {
         cartItemRepository.save(cartItem);
     }
 
+    @Transactional
+    public void deleteCartItem(Cart cart, Long itemId) {
+        CartItem cartItem = cartItemRepository.findByCartIdAndItemId(cart.getId(), itemId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 상품입니다."));
+
+        cartItemRepository.delete(cartItem);
+    }
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
@@ -44,5 +44,10 @@ public class CartItemService {
         cartItemRepository.save(cartItem);
     }
 
+    @Transactional(readOnly = true)
+    public List<CartItem> getCartItems(Cart cart) {
+        return cartItemRepository.findByCart(cart);
+    }
+
 
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
@@ -49,5 +49,14 @@ public class CartItemService {
         return cartItemRepository.findByCart(cart);
     }
 
+    @Transactional
+    public void modifyCartItem(Cart cart, Long itemId, Integer quantity) {
+        CartItem cartItem = cartItemRepository.findByCartIdAndItemId(cart.getId(), itemId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 상품입니다."));
+
+        cartItem.updateQuantity(quantity);
+
+        cartItemRepository.save(cartItem);
+    }
 
 }

--- a/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cartItem/service/CartItemService.java
@@ -1,0 +1,48 @@
+package com.coffeebean.domain.cart.cartItem.service;
+
+import com.coffeebean.domain.cart.cart.entity.Cart;
+import com.coffeebean.domain.cart.cartItem.entity.CartItem;
+import com.coffeebean.domain.cart.cartItem.repository.CartItemRepository;
+import com.coffeebean.domain.item.entity.Item;
+import com.coffeebean.domain.item.service.ItemService;
+import com.coffeebean.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CartItemService {
+
+    private final CartItemRepository cartItemRepository;
+    private final ItemService itemService;
+
+    @Transactional
+    public void addCartItem(Cart cart, Long id, Integer quantity) {
+        Item item = itemService.getItem(id)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 상품입니다."));
+
+        // 장바구니에 이미 존재하는 아이템을 또 장바구니에 추가하면 수량만 추가됨
+        Optional<CartItem> opCartItem = cartItemRepository.findByCartIdAndItemId(cart.getId(), id);
+        if (opCartItem.isPresent()) {
+            CartItem cartItem = opCartItem.get();
+            cartItem.addQuantity(quantity);
+            cartItemRepository.save(cartItem);
+            return;
+        }
+
+        // 장바구니에 존재하지 않는 아이템을 장바구니에 추가하면 장바구니 아이템 항목이 새로 추가됨
+        CartItem cartItem = CartItem.builder()
+                .cart(cart)
+                .item(item)
+                .quantity(quantity)
+                .build();
+
+        cartItemRepository.save(cartItem);
+    }
+
+
+}

--- a/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
+++ b/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
@@ -1,8 +1,13 @@
 package com.coffeebean.global.init;
 
+import com.coffeebean.domain.cart.cart.entity.Cart;
+import com.coffeebean.domain.cart.cart.repository.CartRepository;
+import com.coffeebean.domain.cart.cart.service.CartService;
+import com.coffeebean.domain.cart.cartItem.service.CartItemService;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.coffeebean.domain.item.entity.Item;
@@ -12,6 +17,7 @@ import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.domain.user.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Configuration
 @RequiredArgsConstructor
@@ -20,8 +26,12 @@ public class BaseInit {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final ItemRepository itemRepository;
+	private final CartService cartService;
+	private final CartItemService cartItemService;
+	private final CartRepository cartRepository;
 
 	@Bean
+	@Order(1)
 	public ApplicationRunner initUser() {
 		return args -> {
 			if (userRepository.count() == 0) {
@@ -41,15 +51,16 @@ public class BaseInit {
 	}
 
 	@Bean
+	@Order(2)
 	public ApplicationRunner initItem() {
 		return args -> {
 
 			if (itemRepository.count() == 0) {
 				// 상품 20개 추가
-				for (int i = 0; i < 20; i++) {
+				for (int i = 1; i < 20; i++) {
 					itemRepository.save(Item.builder()
 						.stockQuantity(3)
-						.price(20000 + i * 10)
+						.price(10000 + i * 1000)
 						.description(i + "상품의 설명")
 						.name(i + "상품")
 						.build());
@@ -57,4 +68,18 @@ public class BaseInit {
 			}
 		};
 	}
+
+	@Transactional
+	@Bean
+	@Order(3)
+	public ApplicationRunner initCart() {
+		return args -> {
+			if (cartRepository.count() == 0) {
+				User actor = userRepository.findByEmail("example@exam.com").get();
+				Cart cart = cartService.getMyCart(actor);
+				cartItemService.addCartItem(cart, 3L, 4);
+				cartItemService.addCartItem(cart, 8L, 2);
+			}
+		};
+    }
 }

--- a/backend/src/test/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartControllerTest.java
+++ b/backend/src/test/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartControllerTest.java
@@ -1,0 +1,188 @@
+package com.coffeebean.domain.cart.cart.controller;
+
+import com.coffeebean.domain.cart.cartItem.repository.CartItemRepository;
+import com.coffeebean.domain.user.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class ApiV1CartControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UserService userService;
+
+    private String authToken;
+    @Autowired
+    private CartItemRepository cartItemRepository;
+
+    @BeforeEach
+    void setUp() {
+        authToken = userService.login("example@exam.com", "password");
+    }
+
+    @Test
+    @DisplayName("장바구니에 상품 추가")
+    void addItemToCart() throws Exception {
+        ResultActions resultActions = mvc.perform(
+                        post("/api/v1/carts")
+                                .content("""
+                                        {
+                                            "id": 3,
+                                            "quantity": 1,
+                                            "authToken": "%s"
+                                        }
+                                        """.formatted(authToken).trim().stripIndent())
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+                                )
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1CartController.class))
+                .andExpect(handler().methodName("addCartItemToCart"))
+                .andExpect(jsonPath("$.code").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("장바구니에 상품이 추가되었습니다."));
+    }
+
+    @Test
+    @DisplayName("회원 자신의 장바구니 조회")
+        // 테스트를 위해 데이터 추가 필요
+    void getCarts() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/v1/carts")
+                                .content("""
+                                        {
+                                            "authToken": "%s"
+                                        }
+                                        """.formatted(authToken).trim().stripIndent())
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1CartController.class))
+                .andExpect(handler().methodName("getCarts"))
+                .andExpect(jsonPath("$.code").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("내 장바구니 조회가 완료되었습니다."))
+                .andExpect(jsonPath("$.data.items[0].id").value("3"))
+                .andExpect(jsonPath("$.data.items[0].name").value("3상품"))
+                .andExpect(jsonPath("$.data.items[0].price").value("13000"))
+                .andExpect(jsonPath("$.data.items[0].quantity").value("4"))
+                .andExpect(jsonPath("$.data.items[1].id").value("8"))
+                .andExpect(jsonPath("$.data.items[1].name").value("8상품"))
+                .andExpect(jsonPath("$.data.items[1].price").value("18000"))
+                .andExpect(jsonPath("$.data.items[1].quantity").value("2"));
+    }
+
+    @Test
+    @DisplayName("자신의 장바구니의 상품 수량 변경")
+        // 테스트를 위해 데이터 추가 필요
+    void modifyCartItem() throws Exception {
+        long itemId = 8L;
+        int quantity = 4;
+        ResultActions resultActions = mvc
+                .perform(
+                        put("/api/v1/carts/%d".formatted(itemId))
+                                .content("""
+                                        {
+                                            "quantity": %d,
+                                            "authToken": "%s"
+                                        }
+                                        """.formatted(quantity, authToken).trim().stripIndent())
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1CartController.class))
+                .andExpect(handler().methodName("modifyCartItem"))
+                .andExpect(jsonPath("$.code").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("장바구니의 상품 수량이 변경되었습니다."));
+
+        int savedQuantity = cartItemRepository.findByItemId(itemId).get().getQuantity();
+        assertThat(savedQuantity).isEqualTo(quantity);
+    }
+
+    @Test
+    @DisplayName("자신의 장바구니 상품 삭제")
+    void deleteCartItem() throws Exception {
+        long itemId = 3;
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/api/v1/carts/%d".formatted(itemId))
+                                .content("""
+                                        {
+                                            "authToken": "%s"
+                                        }
+                                        """.formatted(authToken).trim().stripIndent())
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1CartController.class))
+                .andExpect(handler().methodName("deleteCartItem"))
+                .andExpect(jsonPath("$.code").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("장바구니의 상품이 삭제되었습니다."));
+
+        assertThat(cartItemRepository.findByItemId(itemId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("자신의 장바구니 상품 전체 삭제")
+    void deleteCart() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/api/v1/carts")
+                                .content("""
+                                        {
+                                            "authToken": "%s"
+                                        }
+                                        """.formatted(authToken).trim().stripIndent())
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(ApiV1CartController.class))
+                .andExpect(handler().methodName("deleteCart"))
+                .andExpect(jsonPath("$.code").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("장바구니에 담긴 모든 상품이 삭제되었습니다."));
+
+        assertThat(cartItemRepository.findByItemId(3L)).isEmpty();
+        assertThat(cartItemRepository.findByItemId(8L)).isEmpty();
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 자신의 장바구니에 상품 추가
- 자신의 장바구니 상품 수량 변경
- 자신의 장바구니 전체 조회
- 자신의 장바구니 상품 삭제
- 자신의 장바구니 전체 삭제

  <br/>

## 고려 사항
- 장바구니가 없는 상태(장바구니 기능을 처음 사용하는 고객)에서 장바구니 관련 작업 시 내부적으로 장바구니 자동 생성
- 장바구니에 이미 존재하는 상품을 다시 추가하면 상품의 개수만 증가
- 현재 인증을 위해 body에 authToken을 받고 있음
- DB 조회 줄이기 위해 authToken에 ID 추가 필요

## ➕ 이슈 링크
-  #4 

<br/>

<!-- closed #4  -->