### PR TITLE
feat(27): 주문 등록 API의 응답 RsData 형식으로 수정

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -1,7 +1,5 @@
 package com.coffeebean.domain.order.order.controller;
 
-import java.rmi.UnexpectedException;
-
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,8 +27,7 @@ public class ApiV1OrderController {
 	private final UserService userService;
 
 	@PostMapping
-	public RsData<OrderCreateResponse> createOrder(@RequestBody @Valid OrderCreateRequest orderCreateRequest) throws
-		UnexpectedException {
+	public RsData<OrderCreateResponse> createOrder(@RequestBody @Valid OrderCreateRequest orderCreateRequest) {
 		String email = orderCreateRequest.getEmail();
 
 		// 회원이 주문을 등록하는 경우

--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -16,6 +16,7 @@ import com.coffeebean.domain.order.order.service.OrderService;
 import com.coffeebean.domain.order.orderItem.service.OrderItemService;
 import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.domain.user.user.service.UserService;
+import com.coffeebean.global.dto.RsData;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,14 +31,7 @@ public class ApiV1OrderController {
 	private final UserService userService;
 
 	@PostMapping
-	public ResponseEntity createOrder(@RequestBody @Valid OrderCreateRequest orderCreateRequest,
-		BindingResult bindingResult) throws UnexpectedException {
-		if (bindingResult.hasErrors()) {
-			StringBuilder errorMessage = new StringBuilder();
-			bindingResult.getAllErrors().forEach(error -> errorMessage.append(error.getDefaultMessage()).append("\n"));
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage.toString().trim());
-		}
-
+	public ResponseEntity<Order> createOrder(@RequestBody @Valid OrderCreateRequest orderCreateRequest) throws UnexpectedException {
 		String email = orderCreateRequest.getEmail();
 
 		if (orderCreateRequest.getAuthToken() != null) {

--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -2,15 +2,13 @@ package com.coffeebean.domain.order.order.controller;
 
 import java.rmi.UnexpectedException;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.coffeebean.domain.order.order.dto.OrderCreateRequest;
+import com.coffeebean.domain.order.order.dto.OrderCreateResponse;
 import com.coffeebean.domain.order.order.entity.Order;
 import com.coffeebean.domain.order.order.service.OrderService;
 import com.coffeebean.domain.order.orderItem.service.OrderItemService;
@@ -31,9 +29,11 @@ public class ApiV1OrderController {
 	private final UserService userService;
 
 	@PostMapping
-	public ResponseEntity<Order> createOrder(@RequestBody @Valid OrderCreateRequest orderCreateRequest) throws UnexpectedException {
+	public RsData<OrderCreateResponse> createOrder(@RequestBody @Valid OrderCreateRequest orderCreateRequest) throws
+		UnexpectedException {
 		String email = orderCreateRequest.getEmail();
 
+		// 회원이 주문을 등록하는 경우
 		if (orderCreateRequest.getAuthToken() != null) {
 			User actor = userService.getUserByAuthToken(orderCreateRequest.getAuthToken());
 			email = actor.getEmail();
@@ -48,6 +48,10 @@ public class ApiV1OrderController {
 		// Order의 세부 상품 항목들 OderItem 저장
 		orderItemService.createOrderItem(order, orderCreateRequest.getItems());
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(order);
+		return new RsData<>(
+			"201-1",
+			"주문이 등록되었습니다.",
+			new OrderCreateResponse(order)
+		);
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/order/order/dto/OrderCreateResponse.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/dto/OrderCreateResponse.java
@@ -1,0 +1,31 @@
+package com.coffeebean.domain.order.order.dto;
+
+import java.time.LocalDateTime;
+
+import com.coffeebean.domain.order.order.DeliveryStatus;
+import com.coffeebean.domain.order.order.OrderStatus;
+import com.coffeebean.domain.order.order.entity.Order;
+import com.coffeebean.domain.user.user.Address;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OrderCreateResponse {
+	private long id; // 주문ID
+	private String email; // 주문자 이메일
+	private Address deliveryAddress; // 배송 주소
+	private DeliveryStatus deliveryStatus; // 배송 상태
+	private OrderStatus orderStatus; // 주문 상태
+	private LocalDateTime orderDate; // 주문 시간
+
+	public OrderCreateResponse(Order order) {
+		this.id = order.getId();
+		this.email = order.getEmail();
+		this.deliveryAddress = order.getDeliveryAddress();
+		this.deliveryStatus = order.getDeliveryStatus();
+		this.orderStatus = order.getOrderStatus();
+		this.orderDate = order.getOrderDate();
+	}
+}

--- a/backend/src/main/java/com/coffeebean/domain/order/order/service/OrderService.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/service/OrderService.java
@@ -14,6 +14,7 @@ import com.coffeebean.domain.order.order.OrderStatus;
 import com.coffeebean.domain.order.order.entity.Order;
 import com.coffeebean.domain.order.order.repository.OrderRepository;
 import com.coffeebean.domain.user.user.Address;
+import com.coffeebean.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +26,7 @@ public class OrderService {
 	private final OrderRepository orderRepository;
 
 	@Transactional
-	public Order createOrder(String email, String city, String street, String zipcode) throws UnexpectedException {
+	public Order createOrder(String email, String city, String street, String zipcode) {
 		Order order = Order.builder()
 			.email(email)
 			.deliveryAddress(new Address(city, street, zipcode))
@@ -36,7 +37,7 @@ public class OrderService {
 		orderRepository.save(order);
 		orderRepository.flush();
 		return orderRepository.findById(order.getId())
-			.orElseThrow(() -> new UnexpectedException("주문이 등록되지 않았습니다."));
+			.orElseThrow(() -> new ServiceException("500-1", "주문이 등록되지 않았습니다."));
 	}
 
 	/**

--- a/backend/src/main/java/com/coffeebean/global/aspect/ResponseAspect.java
+++ b/backend/src/main/java/com/coffeebean/global/aspect/ResponseAspect.java
@@ -1,0 +1,50 @@
+package com.coffeebean.global.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import com.coffeebean.global.dto.RsData;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ResponseAspect {
+
+	private final HttpServletResponse response;
+
+	@Around("""
+            (
+                within
+                (
+                    @org.springframework.web.bind.annotation.RestController *
+                )
+                &&
+                (
+                    @annotation(org.springframework.web.bind.annotation.GetMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.PostMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.PutMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.DeleteMapping)
+                )
+            )
+            ||
+            @annotation(org.springframework.web.bind.annotation.ResponseBody)
+            """)
+	public Object responseAspect(ProceedingJoinPoint joinPoint) throws Throwable {
+		Object rst = joinPoint.proceed();
+
+		if(rst instanceof RsData rsData) {
+			int statusCode = rsData.getStatusCode();
+			response.setStatus(statusCode);
+		}
+
+		return rst;
+	}
+}

--- a/backend/src/test/java/com/coffeebean/domain/order/order/controller/ApiV1OrderControllerTest.java
+++ b/backend/src/test/java/com/coffeebean/domain/order/order/controller/ApiV1OrderControllerTest.java
@@ -75,12 +75,14 @@ class ApiV1OrderControllerTest {
 			.andExpect(status().isCreated())
 			.andExpect(handler().handlerType(ApiV1OrderController.class))
 			.andExpect(handler().methodName("createOrder"))
-			.andExpect(jsonPath("$.deliveryAddress.city").value("서울"))
-			.andExpect(jsonPath("$.deliveryAddress.street").value("원두아파트 100동 1201호"))
-			.andExpect(jsonPath("$.deliveryAddress.zipcode").value("23578"))
-			.andExpect(jsonPath("$.deliveryStatus").value("READY"))
-			.andExpect(jsonPath("$.orderStatus").value("ORDER"))
-			.andExpect(jsonPath("$.orderDate").isNotEmpty());
+			.andExpect(jsonPath("$.code").value("201-1"))
+			.andExpect(jsonPath("$.msg").value("주문이 등록되었습니다."))
+			.andExpect(jsonPath("$.data.deliveryAddress.city").value("서울"))
+			.andExpect(jsonPath("$.data.deliveryAddress.street").value("원두아파트 100동 1201호"))
+			.andExpect(jsonPath("$.data.deliveryAddress.zipcode").value("23578"))
+			.andExpect(jsonPath("$.data.deliveryStatus").value("READY"))
+			.andExpect(jsonPath("$.data.orderStatus").value("ORDER"))
+			.andExpect(jsonPath("$.data.orderDate").isNotEmpty());
 	}
 
 	@Test
@@ -119,11 +121,13 @@ class ApiV1OrderControllerTest {
 			.andExpect(status().isCreated())
 			.andExpect(handler().handlerType(ApiV1OrderController.class))
 			.andExpect(handler().methodName("createOrder"))
-			.andExpect(jsonPath("$.deliveryAddress.city").value("서울"))
-			.andExpect(jsonPath("$.deliveryAddress.street").value("원두아파트 100동 1201호"))
-			.andExpect(jsonPath("$.deliveryAddress.zipcode").value("23578"))
-			.andExpect(jsonPath("$.deliveryStatus").value("READY"))
-			.andExpect(jsonPath("$.orderStatus").value("ORDER"))
-			.andExpect(jsonPath("$.orderDate").isNotEmpty());
+			.andExpect(jsonPath("$.code").value("201-1"))
+			.andExpect(jsonPath("$.msg").value("주문이 등록되었습니다."))
+			.andExpect(jsonPath("$.data.deliveryAddress.city").value("서울"))
+			.andExpect(jsonPath("$.data.deliveryAddress.street").value("원두아파트 100동 1201호"))
+			.andExpect(jsonPath("$.data.deliveryAddress.zipcode").value("23578"))
+			.andExpect(jsonPath("$.data.deliveryStatus").value("READY"))
+			.andExpect(jsonPath("$.data.orderStatus").value("ORDER"))
+			.andExpect(jsonPath("$.data.orderDate").isNotEmpty());
 	}
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 주문 등록 API 응답 형식 RsDate 형식으로 수정
- 주문 등록 응답에 `OrderCreateResponse` DTO 적용
- `RsData`의 `code`에 따라 HTTP 응답 코드가 자동으로 설정되도록 `global.aspect.ResponseAspect` 추가
  - `RestController`이고 `RsData`를 응답으로 사용하면 적용됨

  <br/>

## 고려 사항
- **`RsData`의 `code`에 따라 HTTP 응답 코드가 자동으로 설정**되도록 추가했습니다.

<br/>

## ➕ 이슈 링크
- #27 

<br/>

<!-- closed #27  -->