### PR TITLE
feat(5): 질문 관리

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/question/answer/entity/Answer.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/entity/Answer.java
@@ -4,19 +4,18 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.coffeebean.domain.question.question.entity.Question;
-import com.coffeebean.domain.user.user.enitity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,6 +28,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Answer {
 
 	@Id
@@ -42,9 +42,6 @@ public class Answer {
 	@OneToOne
 	@JoinColumn(name = "question_id")
 	private Question question;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	private User author;
 
 	@CreatedDate
 	private LocalDateTime createDate;

--- a/backend/src/main/java/com/coffeebean/domain/question/answer/entity/Answer.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/entity/Answer.java
@@ -6,14 +6,17 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import com.coffeebean.domain.question.question.entity.Question;
+import com.coffeebean.domain.user.user.enitity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,6 +42,9 @@ public class Answer {
 	@OneToOne
 	@JoinColumn(name = "question_id")
 	private Question question;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User author;
 
 	@CreatedDate
 	private LocalDateTime createDate;

--- a/backend/src/main/java/com/coffeebean/domain/question/answer/entity/Answer.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/entity/Answer.java
@@ -5,12 +5,16 @@ import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
+import com.coffeebean.domain.question.question.entity.Question;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,6 +35,10 @@ public class Answer {
 	@Lob
 	@Column(columnDefinition = "TEXT")
 	private String content;    // 답변 내용
+
+	@OneToOne
+	@JoinColumn(name = "question_id")
+	private Question question;
 
 	@CreatedDate
 	private LocalDateTime createDate;

--- a/backend/src/main/java/com/coffeebean/domain/question/answer/repository/AnswerRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/repository/AnswerRepository.java
@@ -1,0 +1,10 @@
+package com.coffeebean.domain.question.answer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.coffeebean.domain.question.answer.entity.Answer;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/backend/src/main/java/com/coffeebean/domain/question/answer/repository/AnswerRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/repository/AnswerRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.coffeebean.domain.question.answer.entity.Answer;
+import com.coffeebean.domain.question.question.entity.Question;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+	Answer findByQuestion(Question question);
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/answer/service/AnswerService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/service/AnswerService.java
@@ -1,6 +1,7 @@
 package com.coffeebean.domain.question.answer.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.coffeebean.domain.question.answer.entity.Answer;
 import com.coffeebean.domain.question.answer.repository.AnswerRepository;
@@ -14,6 +15,7 @@ public class AnswerService {
 
 	private final AnswerRepository answerRepository;
 
+	@Transactional
 	public void writeAnswer(Question question, String content) {
 		answerRepository.save(Answer.builder()
 				.content(content)

--- a/backend/src/main/java/com/coffeebean/domain/question/answer/service/AnswerService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/service/AnswerService.java
@@ -1,0 +1,7 @@
+package com.coffeebean.domain.question.answer.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AnswerService {
+}

--- a/backend/src/main/java/com/coffeebean/domain/question/answer/service/AnswerService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/answer/service/AnswerService.java
@@ -2,6 +2,23 @@ package com.coffeebean.domain.question.answer.service;
 
 import org.springframework.stereotype.Service;
 
+import com.coffeebean.domain.question.answer.entity.Answer;
+import com.coffeebean.domain.question.answer.repository.AnswerRepository;
+import com.coffeebean.domain.question.question.entity.Question;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Service
 public class AnswerService {
+
+	private final AnswerRepository answerRepository;
+
+	public void writeAnswer(Question question, String content) {
+		answerRepository.save(Answer.builder()
+				.content(content)
+				.question(question)
+			.build()
+		);
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
@@ -69,4 +69,20 @@ public class ApiV1QuestionController {
 			new QuestionDto(question)
 		);
 	}
+
+
+	// 질문 목록 조회
+	@GetMapping
+	public RsData<List<QuestionDto>> getQuestions() {
+
+		List<QuestionDto> questionLists = questionService.getQuestions().stream()
+			.map(QuestionDto::new)
+			.toList();
+
+		return new RsData<>(
+			"200-1",
+			"질문 목록 조회가 완료되었습니다",
+			questionLists
+		);
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
@@ -2,6 +2,7 @@ package com.coffeebean.domain.question.question.controller;
 
 import java.util.List;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coffeebean.domain.question.answer.service.AnswerService;
 import com.coffeebean.domain.question.question.dto.QuestionDto;
 import com.coffeebean.domain.question.question.entity.Question;
 import com.coffeebean.domain.question.question.service.QuestionService;
@@ -29,6 +31,7 @@ public class ApiV1QuestionController {
 
 	private final QuestionService questionService;
 	private final UserService userService;
+	private final AnswerService answerService;
 
 	record WriteQuestionReqBody(
 		@NotNull(message = "질문할 상품이 선택되지 않았습니다.")
@@ -117,5 +120,22 @@ public class ApiV1QuestionController {
 		@NotNull(message = "인증 정보가 없습니다.")
 		String authToken
 	) {
+	}
+
+	// 질문에 대한 답변 작성
+	@PostMapping("/{id}")
+	public RsData<Void> writeAnswer(@RequestBody @Valid WriteAnswerReqBody writeAnswerReqBody,
+		@PathVariable(name = "id") long questionId) {
+		if (!userService.isAdminByAuthToken(writeAnswerReqBody.authToken())) {
+			throw new ServiceException("403-1", "답변 작성은 관리자만 가능합니다.");
+		}
+
+		Question question = questionService.findQuestionById(questionId);
+		answerService.writeAnswer(question, writeAnswerReqBody.content());
+
+		return new RsData<>(
+			"200-1",
+			"답변이 작성되었습니다."
+		);
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
@@ -1,9 +1,54 @@
 package com.coffeebean.domain.question.question.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coffeebean.domain.question.question.service.QuestionService;
+import com.coffeebean.domain.user.user.enitity.User;
+import com.coffeebean.domain.user.user.service.UserService;
+import com.coffeebean.global.dto.RsData;
+import com.coffeebean.global.exception.ServiceException;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/questions")
 public class ApiV1QuestionController {
+
+	private final QuestionService questionService;
+	private final UserService userService;
+
+	record WriteQuestionReqBody(
+		@NotNull(message = "질문할 상품이 선택되지 않았습니다.")
+		long itemId,
+		@NotBlank(message = "질문 제목을 입력하세요.")
+		String subject,
+		@NotBlank(message = "내용을 입력하세요.")
+		String content,
+		@NotBlank(message = "인증 정보가 없습니다.")
+		String authToken
+	) {
+	}
+
+	@PostMapping
+	public RsData<Void> writeQuestion(@RequestBody @Valid WriteQuestionReqBody writeQuestionReqBody) {
+		User actor = userService.getUserByAuthToken(writeQuestionReqBody.authToken());
+		User realActor = userService.findByEmail(actor.getEmail())
+			.orElseThrow(() -> new ServiceException("401-1", "인증 정보가 잘못되었습니다."));
+
+		questionService.writeQuestion(realActor, writeQuestionReqBody.itemId(), writeQuestionReqBody.subject(),
+			writeQuestionReqBody.content());
+
+		return new RsData<>(
+			"200-1",
+			"질문 작성이 완료되었습니다."
+		);
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
@@ -1,11 +1,16 @@
 package com.coffeebean.domain.question.question.controller;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coffeebean.domain.question.question.dto.QuestionDto;
+import com.coffeebean.domain.question.question.entity.Question;
 import com.coffeebean.domain.question.question.service.QuestionService;
 import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.domain.user.user.service.UserService;
@@ -37,6 +42,7 @@ public class ApiV1QuestionController {
 	) {
 	}
 
+	// 질문 작성
 	@PostMapping
 	public RsData<Void> writeQuestion(@RequestBody @Valid WriteQuestionReqBody writeQuestionReqBody) {
 		User actor = userService.getUserByAuthToken(writeQuestionReqBody.authToken());
@@ -49,6 +55,18 @@ public class ApiV1QuestionController {
 		return new RsData<>(
 			"200-1",
 			"질문 작성이 완료되었습니다."
+		);
+	}
+
+	// 질문 단건 조회
+	@GetMapping("/{id}")
+	public RsData<QuestionDto> findById(@PathVariable long id) {
+		Question question = questionService.findQuestionById(id);
+
+		return new RsData<>(
+			"200-1",
+			"질문에 대한 조회가 완료되었습니다.",
+			new QuestionDto(question)
 		);
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
@@ -95,22 +95,22 @@ public class ApiV1QuestionController {
 	@DeleteMapping("/{id}")
 	public RsData<Void> deleteQuestion(
 		@RequestBody @Valid AuthReqBody authReqBody,
-		@PathVariable(name = "id") Long id) {
-		if (canDeleteQuestion(id, authReqBody.authToken())) {
-			questionService.deleteQuestion(id);
+		@PathVariable(name = "id") Long questionId) {
+		if (canDeleteQuestion(questionId, authReqBody.authToken())) {
+			questionService.deleteQuestion(questionId);
 			return new RsData<>("200-1", "질문이 삭제되었습니다.");
 		}
 		return new RsData<>("403-1", "질문을 삭제할 권한이 없습니다.");
 	}
 
-	private boolean canDeleteQuestion(Long id, String authToken) {
+	private boolean canDeleteQuestion(Long questionId, String authToken) {
 		// 관리자인 경우
 		if (userService.isAdminByAuthToken(authToken)) {
 			return true;
 		}
 		// 작성자인 경우
 		User actor = userService.getUserByAuthToken(authToken);
-		Question question = questionService.findQuestionById(id);
+		Question question = questionService.findQuestionById(questionId);
 		return question.getAuthor().getEmail().equals(actor.getEmail());
 	}
 
@@ -137,5 +137,19 @@ public class ApiV1QuestionController {
 			"200-1",
 			"답변이 작성되었습니다."
 		);
+	}
+
+	// 질문에 대한 답변 삭제
+	@DeleteMapping("/{id}/answers")
+	public RsData<Void> deleteAnswer(
+		@RequestBody @Valid AuthReqBody authReqBody,
+		@PathVariable(name = "id") Long questionId) {
+		if (!userService.isAdminByAuthToken(authReqBody.authToken())) {
+			throw new ServiceException("403-1", "답변 삭제는 관리자만 가능합니다.");
+		}
+
+		questionService.deleteAnswer(questionId);
+
+		return new RsData<>("200-1", "답변이 삭제되었습니다.");
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
@@ -1,0 +1,9 @@
+package com.coffeebean.domain.question.question.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/questions")
+public class ApiV1QuestionController {
+}

--- a/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionController.java
@@ -83,7 +83,7 @@ public class ApiV1QuestionController {
 
 		return new RsData<>(
 			"200-1",
-			"질문 목록 조회가 완료되었습니다",
+			"질문 목록 조회가 완료되었습니다.",
 			questionLists
 		);
 	}

--- a/backend/src/main/java/com/coffeebean/domain/question/question/dto/QuestionDto.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/dto/QuestionDto.java
@@ -1,0 +1,54 @@
+package com.coffeebean.domain.question.question.dto;
+
+import java.time.LocalDateTime;
+
+import com.coffeebean.domain.question.question.entity.Question;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class QuestionDto {
+	long id;
+	String name;
+	String subject;
+	String content;
+	LocalDateTime createDate;
+	LocalDateTime modifyDate;
+	AnswerDto answer;
+
+	@Getter(AccessLevel.PUBLIC)
+	@Setter(AccessLevel.PUBLIC)
+	static class AnswerDto {
+		String content;
+		LocalDateTime createDate;
+		LocalDateTime modifyDate;
+
+		// 생성자 추가 (값이 있는 경우)
+		public AnswerDto(String content, LocalDateTime createDate, LocalDateTime modifyDate) {
+			this.content = content;
+			this.createDate = createDate;
+			this.modifyDate = modifyDate;
+		}
+	}
+
+	public QuestionDto(Question question) {
+		this.id = question.getId();
+		this.name = question.getAuthor().getName();
+		this.subject = question.getSubject();
+		this.content = question.getContent();
+		this.createDate = question.getCreateDate();
+		this.modifyDate = question.getModifyDate();
+
+		// answer가 존재하면 값을 채우고, 없으면 "answer": null
+		if (question.getAnswer() != null) {
+			this.answer = new AnswerDto(
+				question.getAnswer().getContent(),
+				question.getAnswer().getCreateDate(),
+				question.getAnswer().getModifyDate()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/coffeebean/domain/question/question/dto/QuestionDto.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/dto/QuestionDto.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Setter
 public class QuestionDto {
 	long id;
+	long itemId;
 	String name;
 	String subject;
 	String content;
@@ -36,6 +37,7 @@ public class QuestionDto {
 
 	public QuestionDto(Question question) {
 		this.id = question.getId();
+		this.itemId = question.getItem().getId();
 		this.name = question.getAuthor().getName();
 		this.subject = question.getSubject();
 		this.content = question.getContent();

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -51,7 +51,7 @@ public class Question {
 	@OneToOne(mappedBy = "question", cascade = CascadeType.ALL)
 	private Answer answer;
 
-	@OneToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "author_id")
 	private User author;
 

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -2,6 +2,7 @@ package com.coffeebean.domain.question.question.entity;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import com.coffeebean.domain.item.entity.Item;
@@ -50,8 +51,11 @@ public class Question {
 	@JoinColumn(name = "item_id", nullable = false)
 	private Item item;
 
+	@CreatedDate
+	@Setter(AccessLevel.PRIVATE)
 	private LocalDateTime createDate;
 
 	@LastModifiedDate
+	@Setter(AccessLevel.PRIVATE)
 	private LocalDateTime modifyDate;
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -48,7 +48,7 @@ public class Question {
 	@Column(columnDefinition = "TEXT")
 	private String content; // 질문 내용
 
-	@OneToOne(mappedBy = "question", cascade = CascadeType.ALL)
+	@OneToOne(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
 	private Answer answer;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -66,4 +66,8 @@ public class Question {
 	@LastModifiedDate
 	@Setter(AccessLevel.PRIVATE)
 	private LocalDateTime modifyDate;
+
+	public void deleteAnswer() {
+		answer = null;
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.question.answer.entity.Answer;
@@ -11,6 +12,7 @@ import com.coffeebean.domain.user.user.enitity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,6 +34,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Question {
 
 	@Id

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -4,15 +4,18 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.LastModifiedDate;
 
+import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.question.answer.entity.Answer;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -42,6 +45,10 @@ public class Question {
 	@OneToOne
 	@JoinColumn(name = "answer_id")
 	private Answer answer;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "item_id", nullable = false)
+	private Item item;
 
 	private LocalDateTime createDate;
 

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.question.answer.entity.Answer;
+import com.coffeebean.domain.user.user.enitity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,6 +47,10 @@ public class Question {
 	@OneToOne
 	@JoinColumn(name = "answer_id")
 	private Answer answer;
+
+	@OneToOne
+	@JoinColumn(name = "author_id")
+	private User author;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "item_id", nullable = false)

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -52,7 +52,7 @@ public class Question {
 	private Answer answer;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "author_id")
+	@JoinColumn(name = "author_id", nullable = false)
 	private User author;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/entity/Question.java
@@ -10,6 +10,7 @@ import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.question.answer.entity.Answer;
 import com.coffeebean.domain.user.user.enitity.User;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -47,8 +48,7 @@ public class Question {
 	@Column(columnDefinition = "TEXT")
 	private String content; // 질문 내용
 
-	@OneToOne
-	@JoinColumn(name = "answer_id")
+	@OneToOne(mappedBy = "question", cascade = CascadeType.ALL)
 	private Answer answer;
 
 	@OneToOne

--- a/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
@@ -1,5 +1,6 @@
 package com.coffeebean.domain.question.question.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -13,4 +14,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
 	@EntityGraph(attributePaths = {"author", "answer"})
 	Optional<Question> findById(Long id);
+
+	@EntityGraph(attributePaths = {"author", "answer"})
+	List<Question> findAll();
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
@@ -1,0 +1,10 @@
+package com.coffeebean.domain.question.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.coffeebean.domain.question.question.entity.Question;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
@@ -1,5 +1,8 @@
 package com.coffeebean.domain.question.question.repository;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +10,7 @@ import com.coffeebean.domain.question.question.entity.Question;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+	@EntityGraph(attributePaths = {"author", "answer"})
+	Optional<Question> findById(Long id);
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
@@ -1,0 +1,7 @@
+package com.coffeebean.domain.question.question.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class QuestionService {
+}

--- a/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
@@ -1,6 +1,9 @@
 package com.coffeebean.domain.question.question.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.item.service.ItemService;
@@ -18,6 +21,7 @@ public class QuestionService {
 	private final QuestionRepository questionRepository;
 	private final ItemService itemService;
 
+	@Transactional
 	public void writeQuestion(User author, long itemId, String subject, String content) {
 		Item item = itemService.getItem(itemId)
 			.orElseThrow(() -> new DataNotFoundException("존제하지 않는 상품에 질문을 작성할 수 없습니다."));
@@ -30,5 +34,11 @@ public class QuestionService {
 			.build();
 
 		questionRepository.save(question);
+	}
+
+	@Transactional(readOnly = true)
+	public Question findQuestionById(long id) {
+		return questionRepository.findById(id)
+			.orElseThrow(() -> new DataNotFoundException("존재하지 않는 질문입니다."));
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
@@ -11,6 +11,7 @@ import com.coffeebean.domain.question.question.entity.Question;
 import com.coffeebean.domain.question.question.repository.QuestionRepository;
 import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.global.exception.DataNotFoundException;
+import com.coffeebean.global.exception.ServiceException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,5 +46,12 @@ public class QuestionService {
 	@Transactional(readOnly = true)
 	public List<Question> getQuestions() {
 		return questionRepository.findAll();
+	}
+
+	@Transactional
+	public void deleteQuestion(Long id) {
+		Question question = questionRepository.findById(id)
+			.orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 질문입니다."));
+		questionRepository.delete(question);
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
@@ -54,4 +54,11 @@ public class QuestionService {
 			.orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 질문입니다."));
 		questionRepository.delete(question);
 	}
+
+	@Transactional
+	public void deleteAnswer(Long questionId) {
+		Question question = questionRepository.findById(questionId)
+			.orElseThrow(() -> new DataNotFoundException("존재하지 않는 질문입니다."));
+		question.deleteAnswer();
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
@@ -41,4 +41,9 @@ public class QuestionService {
 		return questionRepository.findById(id)
 			.orElseThrow(() -> new DataNotFoundException("존재하지 않는 질문입니다."));
 	}
+
+	@Transactional(readOnly = true)
+	public List<Question> getQuestions() {
+		return questionRepository.findAll();
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
@@ -2,6 +2,33 @@ package com.coffeebean.domain.question.question.service;
 
 import org.springframework.stereotype.Service;
 
+import com.coffeebean.domain.item.entity.Item;
+import com.coffeebean.domain.item.service.ItemService;
+import com.coffeebean.domain.question.question.entity.Question;
+import com.coffeebean.domain.question.question.repository.QuestionRepository;
+import com.coffeebean.domain.user.user.enitity.User;
+import com.coffeebean.global.exception.DataNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Service
 public class QuestionService {
+
+	private final QuestionRepository questionRepository;
+	private final ItemService itemService;
+
+	public void writeQuestion(User author, long itemId, String subject, String content) {
+		Item item = itemService.getItem(itemId)
+			.orElseThrow(() -> new DataNotFoundException("존제하지 않는 상품에 질문을 작성할 수 없습니다."));
+
+		Question question = Question.builder()
+			.author(author)
+			.item(item)
+			.subject(subject)
+			.content(content)
+			.build();
+
+		questionRepository.save(question);
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/user/user/service/UserService.java
+++ b/backend/src/main/java/com/coffeebean/domain/user/user/service/UserService.java
@@ -1,19 +1,15 @@
 package com.coffeebean.domain.user.user.service;
 
-import com.coffeebean.domain.user.user.Address;
 import com.coffeebean.domain.user.user.dto.SignupReqBody;
 import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.domain.user.user.repository.UserRepository;
-import com.coffeebean.global.dto.RsData;
 import com.coffeebean.global.exception.ServiceException;
 import com.coffeebean.global.util.JwtUtil;
 
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -80,7 +76,7 @@ public class UserService {
 	// 일반 사용자 로그인
 	public Map<String, String> loginUser(String email, String password, HttpServletResponse response) {
 		User user = userRepository.findByEmail(email)
-				.orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 이메일입니다."));
+			.orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 이메일입니다."));
 
 		if (!passwordEncoder.matches(password, user.getPassword())) {
 			throw new ServiceException("401-2", "비밀번호가 올바르지 않습니다.");
@@ -102,7 +98,6 @@ public class UserService {
 		return result;
 	}
 
-
 	public User getUserByAuthToken(String token) {
 		Map<String, Object> payload = JwtUtil.getPayload(token);
 		if (payload == null) {
@@ -113,9 +108,22 @@ public class UserService {
 
 		// 이메일만 담겨있는 User 반환
 		return User.builder()
-				.email(email)
-				.build();
+			.email(email)
+			.build();
 	}
 
+	public boolean isAdminByAuthToken(String token) {
+		Map<String, Object> payload = JwtUtil.getPayload(token);
+		if (payload == null) {
+			throw new IllegalArgumentException("잘못된 인증 정보입니다.");
+		}
 
+		if (payload.keySet().contains("role")) {
+			String role = (String)payload.get("role");
+			if (role.equals(ADMIN_ROLE)) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/user/user/service/UserService.java
+++ b/backend/src/main/java/com/coffeebean/domain/user/user/service/UserService.java
@@ -109,7 +109,7 @@ public class UserService {
 			throw new IllegalArgumentException("잘못된 인증 정보입니다.");
 		}
 
-		String email = (String)payload.get("sub"); // email
+		String email = (String)payload.get("email"); // email
 
 		// 이메일만 담겨있는 User 반환
 		return User.builder()

--- a/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
+++ b/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
@@ -30,20 +30,18 @@ public class BaseInit {
 	private final CartItemService cartItemService;
 	private final CartRepository cartRepository;
 
+	@Transactional
 	@Bean
 	@Order(1)
 	public ApplicationRunner initUser() {
 		return args -> {
 			if (userRepository.count() == 0) {
-				String encodedPassword = passwordEncoder.encode("password");
 				User user = User.builder()
 					.email("example@exam.com")
-					.password(encodedPassword) // 암호화 생략
+					.password(passwordEncoder.encode("password")) // 암호화 생략
 					.name("user1")
 					.address(new Address("서울", "관악구 원두아파트", "12345"))
 					.build();
-
-				// User 엔티티를 DB에 저장
 				userRepository.save(user);
 			}
 		};

--- a/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
+++ b/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
@@ -4,6 +4,7 @@ import com.coffeebean.domain.cart.cart.entity.Cart;
 import com.coffeebean.domain.cart.cart.repository.CartRepository;
 import com.coffeebean.domain.cart.cart.service.CartService;
 import com.coffeebean.domain.cart.cartItem.service.CartItemService;
+
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,11 +13,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.item.repository.ItemRepository;
+import com.coffeebean.domain.question.answer.repository.AnswerRepository;
+import com.coffeebean.domain.question.answer.service.AnswerService;
+import com.coffeebean.domain.question.question.entity.Question;
+import com.coffeebean.domain.question.question.repository.QuestionRepository;
 import com.coffeebean.domain.user.user.Address;
 import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.domain.user.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.transaction.annotation.Transactional;
 
 @Configuration
@@ -29,6 +35,9 @@ public class BaseInit {
 	private final CartService cartService;
 	private final CartItemService cartItemService;
 	private final CartRepository cartRepository;
+	private final QuestionRepository questionRepository;
+	private final AnswerService answerService;
+	private final AnswerRepository answerRepository;
 
 	@Transactional
 	@Bean
@@ -78,5 +87,47 @@ public class BaseInit {
 				cartItemService.addCartItem(cart, 8L, 2);
 			}
 		};
-    }
+	}
+
+	@Transactional
+	@Bean
+	@Order(4)
+	public ApplicationRunner initQuestion() {
+		return args -> {
+			if (questionRepository.count() == 0) {
+				long userId = 1L;
+				long itemId = 3L;
+				User user = userRepository.findById(1L).get();
+				Item item = itemRepository.findById(itemId).get();
+				questionRepository.save(Question.builder()
+					.item(item)
+					.author(user)
+					.subject("입고 질문")
+					.content("언제 이 상품이 입고가 될까요")
+					.build());
+
+				long item2Id = 8L;
+				Item item2 = itemRepository.findById(item2Id).get();
+				questionRepository.save(Question.builder()
+					.item(item2)
+					.author(user)
+					.subject("상품 원산지 관련 문의입니다.")
+					.content("상품 원산지 정보가 표시되어 있지 않은데 어디인가요?")
+					.build());
+			}
+		};
+	}
+
+	@Transactional
+	@Bean
+	@Order(5)
+	public ApplicationRunner initAnswer() {
+		return args -> {
+			if (answerRepository.count() == 0) {
+				long questionId = 1L;
+				Question question = questionRepository.findById(questionId).get();
+				answerService.writeAnswer(question, "내일 쯤 입고될 것 같습니다.");
+			}
+		};
+	}
 }

--- a/backend/src/test/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartControllerTest.java
+++ b/backend/src/test/java/com/coffeebean/domain/cart/cart/controller/ApiV1CartControllerTest.java
@@ -1,7 +1,12 @@
 package com.coffeebean.domain.cart.cart.controller;
 
-import com.coffeebean.domain.cart.cartItem.repository.CartItemRepository;
-import com.coffeebean.domain.user.user.service.UserService;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,12 +19,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.charset.StandardCharsets;
+import com.coffeebean.domain.cart.cartItem.repository.CartItemRepository;
+import com.coffeebean.domain.user.user.service.UserService;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Transactional
 @SpringBootTest
@@ -37,9 +40,12 @@ class ApiV1CartControllerTest {
     @Autowired
     private CartItemRepository cartItemRepository;
 
+    @Autowired
+    private HttpServletResponse httpServletResponse;
+
     @BeforeEach
     void setUp() {
-        //  authToken = userService.login("example@exam.com", "password");
+          authToken = userService.loginUser("example@exam.com", "password", httpServletResponse).get("token");
     }
 
     @Test

--- a/backend/src/test/java/com/coffeebean/domain/order/order/controller/ApiV1OrderControllerTest.java
+++ b/backend/src/test/java/com/coffeebean/domain/order/order/controller/ApiV1OrderControllerTest.java
@@ -20,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.coffeebean.domain.user.user.service.UserService;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")

--- a/backend/src/test/java/com/coffeebean/domain/order/order/controller/ApiV1OrderControllerTest.java
+++ b/backend/src/test/java/com/coffeebean/domain/order/order/controller/ApiV1OrderControllerTest.java
@@ -33,10 +33,12 @@ class ApiV1OrderControllerTest {
 	private UserService userService;
 
 	private String authToken;
+	@Autowired
+	private HttpServletResponse httpServletResponse;
 
 	@BeforeEach
 	void setUp() {
-		authToken = userService.login("example@exam.com", "password");
+		authToken = userService.loginUser("example@exam.com", "password", httpServletResponse).get("token");
 	}
 
 	@Test

--- a/backend/src/test/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionControllerTest.java
+++ b/backend/src/test/java/com/coffeebean/domain/question/question/controller/ApiV1QuestionControllerTest.java
@@ -1,0 +1,248 @@
+package com.coffeebean.domain.question.question.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coffeebean.domain.question.answer.entity.Answer;
+import com.coffeebean.domain.question.answer.repository.AnswerRepository;
+import com.coffeebean.domain.question.question.entity.Question;
+import com.coffeebean.domain.question.question.repository.QuestionRepository;
+import com.coffeebean.domain.user.user.service.UserService;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class ApiV1QuestionControllerTest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private HttpServletResponse httpServletResponse;
+
+	private String userAuthToken;
+	private String adminAuthToken;
+	@Autowired
+	private QuestionRepository questionRepository;
+	@Autowired
+	private AnswerRepository answerRepository;
+
+	@BeforeEach
+	void setUp() {
+		userAuthToken = userService.loginUser("example@exam.com", "password", httpServletResponse).get("token");
+		adminAuthToken = userService.loginAdmin("admin", "admin1234", httpServletResponse);
+	}
+
+	@Test
+	@DisplayName("질문 작성")
+	void writeQuestion() throws Exception {
+		long itemId = 1L;
+		ResultActions resultActions = mvc.perform(
+				post("/api/v1/questions")
+					.content("""
+						{
+							"itemId" : "%d",
+						    "subject": "상품 입고 관련 문의입니다.",
+						    "content": "이 상품 입고 언제쯤 될까요?",
+						    "authToken": "%s"
+						}
+						""".formatted(itemId, userAuthToken).trim().stripIndent())
+					.contentType(
+						new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+					)
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(handler().handlerType(ApiV1QuestionController.class))
+			.andExpect(handler().methodName("writeQuestion"))
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("질문 작성이 완료되었습니다."));
+
+		Question question = questionRepository.findById(3L).get();
+		assertThat(question.getItem().getId()).isEqualTo(itemId);
+		assertThat(question.getSubject()).isEqualTo("상품 입고 관련 문의입니다.");
+		assertThat(question.getContent()).isEqualTo("이 상품 입고 언제쯤 될까요?");
+	}
+
+	@Test
+	@DisplayName("질문 단건 조회")
+	void findById() throws Exception {
+		long questionId = 1L;
+		ResultActions resultActions = mvc.perform(
+				get("/api/v1/questions/%d".formatted(questionId))
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(handler().handlerType(ApiV1QuestionController.class))
+			.andExpect(handler().methodName("findById"))
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("질문에 대한 조회가 완료되었습니다."));
+	}
+
+	@Test
+	@DisplayName("질문 전체 조회")
+	void getQuestions() throws Exception {
+		ResultActions resultActions = mvc
+			.perform(
+				get("/api/v1/questions")
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(handler().handlerType(ApiV1QuestionController.class))
+			.andExpect(handler().methodName("getQuestions"))
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("질문 목록 조회가 완료되었습니다."))
+			.andExpect(jsonPath("$.data[0].id").value("1"))
+			.andExpect(jsonPath("$.data[0].itemId").value("3"))
+			.andExpect(jsonPath("$.data[0].name").value("user1"))
+			.andExpect(jsonPath("$.data[0].subject").value("입고 질문"))
+			.andExpect(jsonPath("$.data[0].content").value("언제 이 상품이 입고가 될까요"))
+			.andExpect(jsonPath("$.data[0].answer").isNotEmpty())
+			.andExpect(jsonPath("$.data[0].answer.content").value("내일 쯤 입고될 것 같습니다."))
+			.andExpect(jsonPath("$.data[1].id").value("2"))
+			.andExpect(jsonPath("$.data[1].itemId").value("8"))
+			.andExpect(jsonPath("$.data[1].name").value("user1"))
+			.andExpect(jsonPath("$.data[1].subject").value("상품 원산지 관련 문의입니다."))
+			.andExpect(jsonPath("$.data[1].content").value("상품 원산지 정보가 표시되어 있지 않은데 어디인가요?"))
+			.andExpect(jsonPath("$.data[1].answer").isEmpty());
+	}
+
+	@Test
+	@DisplayName("질문 삭제 - 관리자, 사용자만 삭제 가능")
+	void deleteQuestion() throws Exception {
+		long questionId = 1L;
+		ResultActions resultActions = mvc.perform(
+				delete("/api/v1/questions/%d".formatted(questionId))
+					.content("""
+						{
+						    "authToken": "%s"
+						}
+						""".formatted(userAuthToken).trim().stripIndent())
+					.contentType(
+						new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+					)
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(handler().handlerType(ApiV1QuestionController.class))
+			.andExpect(handler().methodName("deleteQuestion"))
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("질문이 삭제되었습니다."));
+
+		assertThat(questionRepository.findById(questionId)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("질문에 대한 답변 작성")
+	void writeAnswer() throws Exception {
+		long questionId = 2L;
+		ResultActions resultActions = mvc.perform(
+				post("/api/v1/questions/%d".formatted(questionId))
+					.content("""
+						{
+						    "content": "내일 됩니다.",
+						    "authToken": "%s"
+						}
+						""".formatted(adminAuthToken).trim().stripIndent())
+					.contentType(
+						new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+					)
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(handler().handlerType(ApiV1QuestionController.class))
+			.andExpect(handler().methodName("writeAnswer"))
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("답변이 작성되었습니다."));
+
+		Question question = questionRepository.findById(questionId).get();
+		Answer answers = answerRepository.findByQuestion(question);
+		assertThat(answers.getContent()).isEqualTo("내일 됩니다.");
+	}
+
+	@Test
+	@DisplayName("질문에 대한 답변 작성 - User가 하면 작성 실패")
+	void writeAnswerUser() throws Exception {
+		long questionId = 2L;
+		ResultActions resultActions = mvc.perform(
+				post("/api/v1/questions/%d".formatted(questionId))
+					.content("""
+						{
+						    "content": "내일 됩니다.",
+						    "authToken": "%s"
+						}
+						""".formatted(userAuthToken).trim().stripIndent())
+					.contentType(
+						new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+					)
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().isForbidden())
+			.andExpect(handler().handlerType(ApiV1QuestionController.class))
+			.andExpect(handler().methodName("writeAnswer"))
+			.andExpect(jsonPath("$.code").value("403-1"))
+			.andExpect(jsonPath("$.msg").value("답변 작성은 관리자만 가능합니다."));
+	}
+
+	@Test
+	@DisplayName("질문에 대한 답변 삭제")
+	void deleteAnswer() throws Exception {
+		long questionId = 1L;
+		ResultActions resultActions = mvc.perform(
+				delete("/api/v1/questions/%d/answers".formatted(questionId))
+					.content("""
+						{
+						    "authToken": "%s"
+						}
+						""".formatted(adminAuthToken).trim().stripIndent())
+					.contentType(
+						new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+					)
+			)
+			.andDo(print());
+
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(handler().handlerType(ApiV1QuestionController.class))
+			.andExpect(handler().methodName("deleteAnswer"))
+			.andExpect(jsonPath("$.code").value("200-1"))
+			.andExpect(jsonPath("$.msg").value("답변이 삭제되었습니다."));
+
+		Answer savedAnswer = questionRepository.findById(questionId).get().getAnswer();
+		assertThat(savedAnswer).isNull();
+	}
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 질문 작성
- 질문 전체 조회
- 질문 단건 조회(관련 답변까지)
- 질문 삭제
작성자 또는 Admin 권한 필요
- 질문에 대한 답변 작성
Admin 권한 필요
- 질문에 대한 답변 삭제
Admin 권한 필요
- 질문 및 답변 CRUD Test-case 작성

  <br/>
고려사항
- UserService에 isAdminByAuthToken() 메서드 추가
주어진 authToken이 admin인지 확인하는 메서드

엔티티 변경사항
- `Question` Entity에 질문자를 저장하기 위해 `User`와 연관관계 추가
- Question에는 Answer가 없을 수도 있으므로 Answer의 외래키로 Question을 관리하도록 연관관계 수정
<br/>

## ➕ 이슈 링크
- #5

<br/>

<!-- closed #5  -->