### PR TITLE
feat(37): 결제 완료 페이지 화면 레이아웃 구현

### DIFF
--- a/frontend/src/app/cart/ClientPage.tsx
+++ b/frontend/src/app/cart/ClientPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 interface CartItem {
   id: number;
@@ -17,37 +18,6 @@ export default function ClientLayout() {
   ]);
 
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
-
-  // 장바구니 조회 API 연동은 쿠키로 authToken 전달 필요
-  /*
-  //const [cartItems, setCartItems] = useState<CartItem[]>([]);
-
-  // API 요청을 위한 authToken
-  const authToken =
-    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJleGFtcGxlQGV4YW0uY29tIiwiaWF0IjoxNzQwMTAxODYzLCJleHAiOjE3NDAxODgyNjN9._GSZpw5wIYr9QsxLgBjRe0OsnyY6BBEbXzlxm3Inv1A";
-
-  // 장바구니 데이터 불러오기
-  useEffect(() => {
-    fetch("http://localhost:8080/api/v1/carts", {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${authToken}`, // 인증 토큰 추가
-        "Content-Type": "application/json",
-      },
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.code === "200-1") {
-          setCartItems(data.data.items);
-        } else {
-          console.error("장바구니 조회 실패:", data.msg);
-        }
-      })
-      .catch((err) =>
-        console.error("장바구니 데이터를 불러오는 중 오류 발생:", err)
-      );
-  }, []);
-*/
 
   // 개별 상품 선택/해제 핸들러
   const toggleSelection = (id: number) => {
@@ -85,6 +55,33 @@ export default function ClientLayout() {
   const totalPrice = cartItems
     .filter((item) => selectedItems.includes(item.id))
     .reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  // 결제하기 버튼 클릭 시 세션 스토리지에 데이터 저장
+  const handleCheckout = () => {
+    const selectedProducts = cartItems.filter((item) =>
+      selectedItems.includes(item.id)
+    );
+    if (selectedProducts.length === 0) {
+      alert("선택된 상품이 없습니다.");
+      return;
+    }
+
+    const orderData = {
+      items: selectedProducts.map((item) => ({
+        itemId: item.id,
+        count: item.quantity,
+      })),
+      address: {
+        city: "서울",
+        street: "강남대로 123",
+        zipcode: "12345",
+      },
+      email: "user@example.com",
+      totalAmount: totalPrice, // 총 가격을 세션 스토리지에 저장
+    };
+
+    sessionStorage.setItem("orderData", JSON.stringify(orderData));
+  };
 
   return (
     <div className="p-4">
@@ -163,16 +160,19 @@ export default function ClientLayout() {
         <div className="mt-6 p-4 border-t text-right font-semibold text-lg">
           총 가격:{" "}
           <span className="text-blue-600">{totalPrice.toLocaleString()}원</span>
-          <button
-            disabled={selectedItems.length === 0}
-            className={`ml-4 px-4 py-2 rounded ${
-              selectedItems.length > 0
-                ? "bg-blue-500 hover:bg-blue-600 text-white"
-                : "bg-gray-300 text-gray-500 cursor-not-allowed"
-            }`}
-          >
-            결제하기
-          </button>
+          <Link href="/orders/complete">
+            <button
+              onClick={handleCheckout}
+              disabled={selectedItems.length === 0}
+              className={`ml-4 px-4 py-2 rounded ${
+                selectedItems.length > 0
+                  ? "bg-blue-500 hover:bg-blue-600 text-white"
+                  : "bg-gray-300 text-gray-500 cursor-not-allowed"
+              }`}
+            >
+              결제하기
+            </button>
+          </Link>
         </div>
       )}
     </div>

--- a/frontend/src/app/orders/complete/ClientPage.tsx
+++ b/frontend/src/app/orders/complete/ClientPage.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function ClinetLayout() {
+  return <div className="p-4">결제 완료 페이지</div>;
+}

--- a/frontend/src/app/orders/complete/ClientPage.tsx
+++ b/frontend/src/app/orders/complete/ClientPage.tsx
@@ -1,5 +1,80 @@
 "use client";
 
-export default function ClinetLayout() {
-  return <div className="p-4">결제 완료 페이지</div>;
+import { useEffect, useState } from "react";
+
+export default function PaymentSuccessPage() {
+  const [orderData, setOrderData] = useState<{
+    items: { itemId: number; count: number }[];
+    address: { city: string; street: string; zipcode: string };
+    email: string;
+    totalAmount: number | null;
+  } | null>(null);
+
+  useEffect(() => {
+    // 세션 스토리지에서 주문 데이터 가져오기
+    const storedOrderData = sessionStorage.getItem("orderData");
+    if (!storedOrderData) {
+      alert("유효하지 않은 접근입니다.");
+      window.location.href = "/"; // 메인 페이지로 리디렉트
+      return;
+    }
+
+    const parsedOrderData = JSON.parse(storedOrderData);
+    setOrderData({
+      ...parsedOrderData,
+      totalAmount: null, // 초기에는 총 결제 금액을 null로 설정
+    });
+
+    // 상품 가격을 가져와서 총 결제 금액 계산
+    async function fetchTotalPrice() {
+      let total = 0;
+      for (const item of parsedOrderData.items) {
+        try {
+          const response = await fetch(
+            `http://localhost:80080/api/v1/items/${item.itemId}`
+          );
+          const data = await response.json();
+          total += data.price * item.count;
+        } catch (error) {
+          console.error("상품 가격 조회 실패", error);
+        }
+      }
+      setOrderData((prev) => prev && { ...prev, totalAmount: total });
+    }
+
+    fetchTotalPrice();
+  }, []);
+
+  if (!orderData) return null;
+
+  return (
+    <div className="p-6 max-w-md mx-auto bg-white rounded-xl shadow-md space-y-4">
+      <h1 className="text-2xl font-bold text-center">결제 완료</h1>
+      <p className="text-gray-700">주문자 이메일: {orderData.email}</p>
+      <p className="text-gray-700">
+        배송지: {orderData.address.city}, {orderData.address.street},{" "}
+        {orderData.address.zipcode}
+      </p>
+
+      <div className="border-t pt-4">
+        <h2 className="text-lg font-semibold">주문 내역</h2>
+        {orderData.items.map((item, index) => (
+          <p key={index} className="text-gray-600">
+            상품 {item.itemId}: {item.count}개
+          </p>
+        ))}
+      </div>
+
+      <div className="border-t pt-4">
+        <h2 className="text-lg font-semibold">총 결제 금액</h2>
+        {orderData.totalAmount !== null ? (
+          <p className="text-xl font-bold text-green-600">
+            {orderData.totalAmount.toLocaleString()}원
+          </p>
+        ) : (
+          <p className="text-gray-500">가격 계산 중...</p>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/orders/complete/ClientPage.tsx
+++ b/frontend/src/app/orders/complete/ClientPage.tsx
@@ -7,7 +7,7 @@ export default function PaymentSuccessPage() {
     items: { itemId: number; count: number }[];
     address: { city: string; street: string; zipcode: string };
     email: string;
-    totalAmount: number | null;
+    totalAmount: number;
   } | null>(null);
 
   useEffect(() => {
@@ -20,60 +20,36 @@ export default function PaymentSuccessPage() {
     }
 
     const parsedOrderData = JSON.parse(storedOrderData);
-    setOrderData({
-      ...parsedOrderData,
-      totalAmount: null, // 초기에는 총 결제 금액을 null로 설정
-    });
-
-    // 상품 가격을 가져와서 총 결제 금액 계산
-    async function fetchTotalPrice() {
-      let total = 0;
-      for (const item of parsedOrderData.items) {
-        try {
-          const response = await fetch(
-            `http://localhost:80080/api/v1/items/${item.itemId}`
-          );
-          const data = await response.json();
-          total += data.price * item.count;
-        } catch (error) {
-          console.error("상품 가격 조회 실패", error);
-        }
-      }
-      setOrderData((prev) => prev && { ...prev, totalAmount: total });
-    }
-
-    fetchTotalPrice();
+    setOrderData(parsedOrderData); // 세션에서 불러온 데이터 그대로 사용
   }, []);
 
   if (!orderData) return null;
 
   return (
-    <div className="p-6 max-w-md mx-auto bg-white rounded-xl shadow-md space-y-4">
-      <h1 className="text-2xl font-bold text-center">결제 완료</h1>
-      <p className="text-gray-700">주문자 이메일: {orderData.email}</p>
-      <p className="text-gray-700">
+    <div className="p-8 max-w-4xl mx-auto bg-white rounded-xl shadow-lg space-y-6 pt-8">
+      <h1 className="text-3xl font-bold text-center text-gray-800">
+        결제 완료
+      </h1>
+      <p className="text-lg text-gray-700">주문자 이메일: {orderData.email}</p>
+      <p className="text-lg text-gray-700">
         배송지: {orderData.address.city}, {orderData.address.street},{" "}
         {orderData.address.zipcode}
       </p>
 
-      <div className="border-t pt-4">
-        <h2 className="text-lg font-semibold">주문 내역</h2>
+      <div className="border-t pt-6">
+        <h2 className="text-xl font-semibold text-gray-800">주문 내역</h2>
         {orderData.items.map((item, index) => (
-          <p key={index} className="text-gray-600">
+          <p key={index} className="text-lg text-gray-600">
             상품 {item.itemId}: {item.count}개
           </p>
         ))}
       </div>
 
-      <div className="border-t pt-4">
-        <h2 className="text-lg font-semibold">총 결제 금액</h2>
-        {orderData.totalAmount !== null ? (
-          <p className="text-xl font-bold text-green-600">
-            {orderData.totalAmount.toLocaleString()}원
-          </p>
-        ) : (
-          <p className="text-gray-500">가격 계산 중...</p>
-        )}
+      <div className="border-t pt-6">
+        <h2 className="text-xl font-semibold text-gray-800">총 결제 금액</h2>
+        <p className="text-2xl font-bold text-green-600">
+          {orderData.totalAmount.toLocaleString()}원
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/app/orders/complete/page.tsx
+++ b/frontend/src/app/orders/complete/page.tsx
@@ -1,0 +1,9 @@
+import ClientPage from "./ClientPage";
+
+export default function Page() {
+  return (
+    <>
+      <ClientPage />
+    </>
+  );
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 결제 완료 페이지의 화면 레이아웃 구현

  <br/>

## 이미지 첨부
**장바구니 페이지에서 주문할 상품을 선택**
<img width="1584" alt="1" src="https://github.com/user-attachments/assets/403655ef-f960-488c-9be9-2c34cf40f2b4" />

**결제 완료 페이지에 선택된 상품의 주문 결과 출력**
<img width="1579" alt="2" src="https://github.com/user-attachments/assets/fc5fd908-7b4f-4415-8d66-dfa35c8b6a8b" />

<br/>

## 고려 사항
- 현재는 장바구니 페이지에서 선택된 상품들을 브라우저의 SessionDB에 넣어 데이터를 전달하도록 했습니다.
- 결제 페이지를 만들어 결제 페이지에서 결제 정보(이메일, 배송지)를 입력하고 `결제하기`를 누르면 주문 등록이 요청되고, 그 응답을 연결해 결제 완료 페이지의 화면을 구성하도록 변경할 예정입니다.

## ➕ 이슈 링크
- #37 

<br/>

<!-- closed #37   -->