### PR TITLE
feat(42): 인증/인가 Custom Annotation 구현

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/item/controller/ApiV1ItemController.java
+++ b/backend/src/main/java/com/coffeebean/domain/item/controller/ApiV1ItemController.java
@@ -6,6 +6,8 @@ import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.item.service.ItemService;
 import com.coffeebean.global.dto.RsData;
 import com.coffeebean.global.exception.ServiceException;
+import com.coffeebean.global.security.annotations.AdminOnly;
+
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +32,7 @@ public class ApiV1ItemController {
     }
 
     // 상품 등록
+    @AdminOnly
     @PostMapping
     public RsData<Item> addItem(@RequestBody @Valid AddReqBody reqBody) {
         Item item = itemService.addItem(reqBody.name(), reqBody.price(), reqBody.stockQuantity(), reqBody.description());
@@ -72,6 +75,7 @@ public class ApiV1ItemController {
     }
 
     // 상품 삭제
+    @AdminOnly
     @DeleteMapping("/{id}")
     @Transactional
     public RsData<Void> deleteItem(@PathVariable long id) {
@@ -97,6 +101,7 @@ public class ApiV1ItemController {
     }
 
     // 상품 수정
+    @AdminOnly
     @PutMapping("/{id}")
     @Transactional
     public RsData<Void> modifyItem(@PathVariable long id, @RequestBody ModifyReqBody reqBody) {

--- a/backend/src/main/java/com/coffeebean/global/aspect/AdminOnlyAspect.java
+++ b/backend/src/main/java/com/coffeebean/global/aspect/AdminOnlyAspect.java
@@ -29,7 +29,7 @@ public class AdminOnlyAspect {
 	public void before() {
 		// Authorization 헤더 검증
 		String authHeader = request.getHeader("Authorization");
-		if (authHeader != null || authHeader.startsWith("Bearer ")) {
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
 			throw new ServiceException("401-1", "인증 정보가 없거나 잘못되었습니다.");
 		}
 

--- a/backend/src/main/java/com/coffeebean/global/aspect/AdminOnlyAspect.java
+++ b/backend/src/main/java/com/coffeebean/global/aspect/AdminOnlyAspect.java
@@ -1,0 +1,48 @@
+package com.coffeebean.global.aspect;
+
+import java.util.Map;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import com.coffeebean.global.exception.ServiceException;
+import com.coffeebean.global.util.JwtUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class AdminOnlyAspect {
+
+	private final HttpServletRequest request;
+
+	// AdminOnly 애너테이션이 붙은 메서드를 가로채는 Pointcut
+	@Pointcut("@annotation(com.coffeebean.global.security.annotations.AdminOnly)")
+	public void checkAdminPointcut() {
+	}
+
+	@Before("checkAdminPointcut()")
+	public void before() {
+		// Authorization 헤더 검증
+		String authHeader = request.getHeader("Authorization");
+		if (authHeader != null || authHeader.startsWith("Bearer ")) {
+			throw new ServiceException("401-1", "인증 정보가 없거나 잘못되었습니다.");
+		}
+
+		Map<String, Object> payload;
+		try {
+			payload = JwtUtil.getPayload(authHeader.substring("Bearer ".length()));
+		} catch (Exception e) {
+			throw new ServiceException("401-2", "유효하지 않은 인증 토큰입니다.");
+		}
+
+		// 토큰에 관리자 권한이 있는지 검증
+		if (!payload.containsKey("role") || !payload.get("role").equals("ROLE_ADMIN")) {
+			throw new ServiceException("403-1", "접근 권한이 없습니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/coffeebean/global/security/annotations/AdminOnly.java
+++ b/backend/src/main/java/com/coffeebean/global/security/annotations/AdminOnly.java
@@ -1,0 +1,11 @@
+package com.coffeebean.global.security.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AdminOnly {
+}

--- a/backend/src/test/java/com/coffeebean/ApiV1ItemControllerTest.java
+++ b/backend/src/test/java/com/coffeebean/ApiV1ItemControllerTest.java
@@ -1,60 +1,160 @@
 package com.coffeebean;
 
-import com.coffeebean.domain.item.entity.Item;
-import com.coffeebean.domain.item.service.ItemService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.coffeebean.domain.item.controller.ApiV1ItemController;
+import com.coffeebean.domain.item.entity.Item;
+import com.coffeebean.domain.item.service.ItemService;
+import com.coffeebean.domain.user.user.service.UserService;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@Transactional
 @SpringBootTest
 @ActiveProfiles("test")
-@Transactional
+@AutoConfigureMockMvc
 public class ApiV1ItemControllerTest {
 
-    @Autowired
-    private ItemService itemService;
+	@Autowired
+	private MockMvc mvc;
 
-    @Test
-    @DisplayName("커피 등록 및 조회")
-    void addItem() {
-        itemService.addItem("커피1", 1000, 10, "브라질 원두");
-        itemService.addItem("커피2", 3000, 40, "미국 원두");
-        itemService.addItem("커피3", 4000, 50, "케냐 원두");
-        itemService.addItem("커피4", 6000, 12, "이탈리아 원두");
-        itemService.addItem("커피5", 7000, 8, "가나 원두");
+	@Autowired
+	private ItemService itemService;
 
-        // 저장된 아이템 목록 가져오기 (가정: getItems() 메서드가 존재)
-        List<Item> items = itemService.getItems();
+	@Autowired
+	private UserService userService;
 
-        assertThat(items).hasSize(5); // 아이템 개수 확인
+	@Autowired
+	private HttpServletResponse response;
 
-        assertThat(items).extracting(Item::getName)
-                .containsExactly("커피1", "커피2", "커피3", "커피4", "커피5");
+	String adminAuthToken;
 
-        assertThat(items).extracting(Item::getPrice)
-                .containsExactly(1000, 3000, 4000, 6000, 7000);
+	String userAuthToken;
 
-        assertThat(items).extracting(Item::getStockQuantity)
-                .containsExactly(10, 40, 50, 12, 8);
+	@BeforeEach
+	void setUp() {
+		adminAuthToken = userService.loginAdmin("admin", "admin1234", response);
+		userAuthToken = userService.loginUser("example@exam.com", "password", response).get("token");
+	}
 
-        assertThat(items).extracting(Item::getDescription)
-                .containsExactly("브라질 원두", "미국 원두", "케냐 원두", "이탈리아 원두", "가나 원두");
-    }
+	@Test
+	@DisplayName("커피 등록 및 조회")
+	void addItem() {
+		itemService.addItem("커피1", 1000, 10, "브라질 원두");
+		itemService.addItem("커피2", 3000, 40, "미국 원두");
+		itemService.addItem("커피3", 4000, 50, "케냐 원두");
+		itemService.addItem("커피4", 6000, 12, "이탈리아 원두");
+		itemService.addItem("커피5", 7000, 8, "가나 원두");
 
-    @Test
-    @DisplayName("단건 조회")
-    void getItem() {
+		// 저장된 아이템 목록 가져오기 (가정: getItems() 메서드가 존재)
+		List<Item> items = itemService.getItems();
 
-        Item item = itemService.getItem(1).get();
+		assertThat(items).hasSize(5); // 아이템 개수 확인
 
-        assertThat(item.getName()).isEqualTo("커피1");
-    }
+		assertThat(items).extracting(Item::getName)
+			.containsExactly("커피1", "커피2", "커피3", "커피4", "커피5");
+
+		assertThat(items).extracting(Item::getPrice)
+			.containsExactly(1000, 3000, 4000, 6000, 7000);
+
+		assertThat(items).extracting(Item::getStockQuantity)
+			.containsExactly(10, 40, 50, 12, 8);
+
+		assertThat(items).extracting(Item::getDescription)
+			.containsExactly("브라질 원두", "미국 원두", "케냐 원두", "이탈리아 원두", "가나 원두");
+	}
+
+	@Test
+	@DisplayName("단건 조회")
+	void getItem() {
+
+		Item item = itemService.getItem(1).get();
+
+		assertThat(item.getName()).isEqualTo("커피1");
+	}
+
+	@Nested
+	@DisplayName("상품 삭제")
+	class deleteItem {
+
+		@Test
+		@DisplayName("성공 - 관리자는 상품을 삭제할 수 있다")
+		void deleteItemA_AdminRole() throws Exception {
+			var itemId = 1L;
+
+			ResultActions resultActions = mvc.perform(
+					delete("/api/v1/items/%d".formatted(itemId))
+						.header("Authorization", "Bearer " + adminAuthToken)
+				)
+				.andDo(print());
+
+			resultActions
+				.andExpect(status().isOk())
+				.andExpect(handler().handlerType(ApiV1ItemController.class))
+				.andExpect(handler().methodName("deleteItem"))
+				.andExpect(jsonPath("$.code").value("200-1"))
+				.andExpect(jsonPath("$.msg").value(itemId + "번 상품 삭제가 완료되었습니다."));
+
+			assertThat(itemService.getItem(itemId)).isEmpty();
+		}
+
+		@Test
+		@DisplayName("실패 - Admin 권한이 없는 일반 회원이 상품을 삭제하면 실패한다")
+		void deleteItemB_noAdminRole() throws Exception {
+			var itemId = 1L;
+
+			ResultActions resultActions = mvc.perform(
+					delete("/api/v1/items/%d".formatted(itemId))
+						.header("Authorization", "Bearer " + userAuthToken)
+				)
+				.andDo(print());
+
+			resultActions
+				.andExpect(status().isForbidden())
+				.andExpect(handler().handlerType(ApiV1ItemController.class))
+				.andExpect(handler().methodName("deleteItem"))
+				.andExpect(jsonPath("$.code").value("403-1"))
+				.andExpect(jsonPath("$.msg").value("접근 권한이 없습니다."));
+
+			assertThat(itemService.getItem(itemId)).isNotEmpty();
+		}
+
+		@Test
+		@DisplayName("실패 - 로그인하지 않은 비회원이 상품을 삭제하면 실패한다")
+		void deleteItemC_noAuth() throws Exception {
+			var itemId = 1L;
+
+			ResultActions resultActions = mvc.perform(
+					delete("/api/v1/items/%d".formatted(itemId))
+				)
+				.andDo(print());
+
+			resultActions
+				.andExpect(status().isUnauthorized())
+				.andExpect(handler().handlerType(ApiV1ItemController.class))
+				.andExpect(handler().methodName("deleteItem"))
+				.andExpect(jsonPath("$.code").value("401-1"))
+				.andExpect(jsonPath("$.msg").value("인증 정보가 없거나 잘못되었습니다."));
+
+			assertThat(itemService.getItem(itemId)).isNotEmpty();
+		}
+	}
 }
 


### PR DESCRIPTION
## 🔎 작업 내용
- `Authorization: Bearer <access_token>` 형식으로 헤더를 통해 토큰이 넘어올 때 Admin 권한을 확인하는 `@AdminOnly` 애너테이션 추가

### **애너테이션 동작**
- `@AdminOnly` 애너테이션이 붙은 메서드가 실행되면 요청 헤더의 토큰으로 Admin 권한이 있는지 검사합니다.
- **비회원일 때(인증 정보가 없거나 잘못됨)** -> `ServiceException("401-1", "인증 정보가 없거나 잘못되었습니다.")`
- **회원일 때(로그인 했지만 Admin 권한 없음)** -> `ServiceException("403-1", "접근 권한이 없습니다.")`
- **잘못된 토큰 형식, 만료된 토큰** -> `ServiceException("401-2", "유효하지 않은 인증 토큰입니다.")`
- **관리자일 때** -> 메서드 기능 수행

  <br/>

## 고려 사항
- 동작 테스트를 위해 상품 등록, 수정, 삭제 컨트롤러 메서드에 `@AdminOnly`를 적용하고
- `ApiV1ItemControllerTest`에 상품 삭제 테스트를 추가했습니다. (마지막 2개 커밋)
- 코드상 크게 변경사항은 없어서 이대로 사용하셔도 괜찮고, 새로 만드셔도 좋습니다!

## 이미지 첨부
<img width="507" alt="스크린샷 2025-02-23 오전 3 03 26" src="https://github.com/user-attachments/assets/bf198b42-d10e-401c-a2ee-cb389ef9562e" />

<br/>

## ➕ 이슈 링크
- #42 

<br/>

<!-- closed #42  -->