### PR TITLE
[BUG]상품 수정 문제

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/item/controller/ApiV1ItemController.java
+++ b/backend/src/main/java/com/coffeebean/domain/item/controller/ApiV1ItemController.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/items")
@@ -61,7 +62,7 @@ public class ApiV1ItemController {
     public RsData<ItemDto> getItem(@PathVariable long id) {
 
         Item item = itemService.getItem(id).orElseThrow(
-                ()-> new ServiceException("404-1", "존재하지 않는 상품입니다.")
+                () -> new ServiceException("404-1", "존재하지 않는 상품입니다.")
         );
 
         return new RsData<>(
@@ -76,7 +77,7 @@ public class ApiV1ItemController {
     @Transactional
     public RsData<Void> deleteItem(@PathVariable long id) {
         Item item = itemService.getItem(id).orElseThrow(
-                ()-> new ServiceException("404-1", "존재하지 않는 상품입니다.")
+                () -> new ServiceException("404-1", "존재하지 않는 상품입니다.")
         );
 
         itemService.deleteItem(item);
@@ -84,7 +85,7 @@ public class ApiV1ItemController {
         return new RsData<>(
                 "200-1",
                 "%d번 상품 삭제가 완료되었습니다.".formatted(id)
-                );
+        );
 
     }
 
@@ -101,10 +102,10 @@ public class ApiV1ItemController {
     @Transactional
     public RsData<Void> modifyItem(@PathVariable long id, @RequestBody ModifyReqBody reqBody) {
         Item item = itemService.getItem(id).orElseThrow(
-                ()-> new ServiceException("404-1", "존재하지 않는 상품입니다.")
+                () -> new ServiceException("404-1", "존재하지 않는 상품입니다.")
         );
 
-        Item modifyItem= itemService.modifyItem(item, reqBody.name(), reqBody.price(), reqBody.stockQuantity(), reqBody.description());
+        Item modifyItem = itemService.modifyItem(item, reqBody.name(), reqBody.price(), reqBody.stockQuantity(), reqBody.description());
 
         return new RsData<>(
                 "200-1",
@@ -112,4 +113,26 @@ public class ApiV1ItemController {
         );
 
     }
+
+    // 재고 수량만 변경
+    @PatchMapping("/{id}/stock")
+    public RsData<Void> modifyStock(@PathVariable long id, @RequestBody Map<String, Integer> body) {
+        Item item = itemService.getItem(id).orElseThrow(
+                () -> new ServiceException("404-1", "존재하지 않는 상품입니다.")
+        );
+
+        // 변경된 재고값 업데이트
+        if (body.containsKey("stockQuantity")) {
+            int newStockQuntity = body.get("stockQuantity");
+            itemService.updateStockQuantity(item, newStockQuntity);
+        } else {
+            throw new ServiceException("400-1", "재고가 입력되지 않았습니다.");
+        }
+
+        return new RsData<>(
+                "200-1",
+                "'%s' 상품의 재고가 %d개로 변경되었습니다.".formatted(item.getName(), body.get("stockQuantity"))
+        );
+    }
+
 }

--- a/backend/src/main/java/com/coffeebean/domain/item/service/ItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/item/service/ItemService.java
@@ -54,4 +54,9 @@ public class ItemService {
         item.setDescription(description);
         return item;
     }
+
+    public void updateStockQuantity(Item item, int newStockQuntity) {
+        item.setStockQuantity(newStockQuntity);
+        itemRepository.save(item);
+    }
 }

--- a/backend/src/main/java/com/coffeebean/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/coffeebean/global/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
         // 허용할 오리진 설정
         configuration.setAllowedOrigins(Arrays.asList("https://cdpn.io", AppConfig.getSiteFrontUrl()));
         // 허용할 HTTP 메서드 설정
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
         // 자격 증명 허용 설정
         configuration.setAllowCredentials(true);
         // 허용할 헤더 설정

--- a/frontend/src/app/admin/checkItems/ClientPage.tsx
+++ b/frontend/src/app/admin/checkItems/ClientPage.tsx
@@ -8,16 +8,8 @@ type Item = {
   stockQuantity: number;
 };
 
-// 테스트용 하드코딩 데이터
-const initialItems: Item[] = [
-  { id: 1, name: "에티오피아 원두", stockQuantity: 50 },
-  { id: 2, name: "콜롬비아 원두", stockQuantity: 30 },
-  { id: 3, name: "과테말라 원두", stockQuantity: 20 },
-  { id: 4, name: "브라질 원두", stockQuantity: 15 },
-];
-
 export default function CheckItemsPage() {
-  const [items, setItems] = useState<Item[]>(initialItems);
+  const [items, setItems] = useState<Item[]>([]); // 초기값 변경
   const [updatedStocks, setUpdatedStocks] = useState<Record<number, number>>(
     {}
   );
@@ -53,11 +45,10 @@ export default function CheckItemsPage() {
     }
 
     try {
-      // 백엔드 연동
       const response = await fetch(
-        `http://localhost:8080/api/v1/items/${itemId}`,
+        `http://localhost:8080/api/v1/items/${itemId}/stock`,
         {
-          method: "PUT",
+          method: "PATCH", // PUT->PATCH로 변경
           headers: {
             "Content-Type": "application/json",
           },


### PR DESCRIPTION
- 제목 : #36 

## 🔎 작업 내용

- 관리자 페이지의 재고수량 페이지에서 재고 수량 변경시 재고 외 다른 필드에 null값이 들어가는 오류발생
    - PATCH 메서드 허용을 하여 이슈 해결
    - PATCH - items/{id}/stock 추가
    - 현재 재고만 수정 가능 
- 재고확인 페이지의 메서드 PUT에서 PATCH로 변경
    - 테스트를 위해 입력한 더미 데이터 삭제
    - 정상적으로 동작함

  <br/>

## ➕ 이슈 링크
- #36 

<br/>

<!-- closed #번호 -->