### PR TITLE
feat(47): 주문 등록 API 성공 응답 데이터 수정

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -1,5 +1,7 @@
 package com.coffeebean.domain.order.order.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +11,7 @@ import com.coffeebean.domain.order.order.dto.OrderCreateRequest;
 import com.coffeebean.domain.order.order.dto.OrderCreateResponse;
 import com.coffeebean.domain.order.order.entity.Order;
 import com.coffeebean.domain.order.order.service.OrderService;
+import com.coffeebean.domain.order.orderItem.entity.OrderItem;
 import com.coffeebean.domain.order.orderItem.service.OrderItemService;
 import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.domain.user.user.service.UserService;
@@ -43,12 +46,12 @@ public class ApiV1OrderController {
 			orderCreateRequest.getAddress().getZipcode());
 
 		// Order의 세부 상품 항목들 OderItem 저장
-		orderItemService.createOrderItem(order, orderCreateRequest.getItems());
+		List<OrderItem> orderItems = orderItemService.createOrderItem(order, orderCreateRequest.getItems());
 
 		return new RsData<>(
 			"201-1",
 			"주문이 등록되었습니다.",
-			new OrderCreateResponse(order)
+			new OrderCreateResponse(order, orderItems)
 		);
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/order/order/dto/OrderCreateResponse.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/dto/OrderCreateResponse.java
@@ -1,10 +1,13 @@
 package com.coffeebean.domain.order.order.dto;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.coffeebean.domain.order.order.DeliveryStatus;
 import com.coffeebean.domain.order.order.OrderStatus;
 import com.coffeebean.domain.order.order.entity.Order;
+import com.coffeebean.domain.order.orderItem.entity.OrderItem;
 import com.coffeebean.domain.user.user.Address;
 
 import lombok.Getter;
@@ -19,13 +22,38 @@ public class OrderCreateResponse {
 	private DeliveryStatus deliveryStatus; // 배송 상태
 	private OrderStatus orderStatus; // 주문 상태
 	private LocalDateTime orderDate; // 주문 시간
+	private List<OrderItemBody> items = new ArrayList<>();
+	private int totalPrice; // 총 가격
 
-	public OrderCreateResponse(Order order) {
+	@Getter
+	@Setter
+	static class OrderItemBody {
+		private long id;
+		private String name;
+		private int count;
+		private int price;
+
+		public OrderItemBody(OrderItem orderItem) {
+			this.id = orderItem.getItem().getId();
+			this.name = orderItem.getItem().getName();
+			this.price = orderItem.getItem().getPrice();
+			this.count = orderItem.getCount();
+		}
+	}
+
+	public OrderCreateResponse(Order order, List<OrderItem> orderItems) {
 		this.id = order.getId();
 		this.email = order.getEmail();
 		this.deliveryAddress = order.getDeliveryAddress();
 		this.deliveryStatus = order.getDeliveryStatus();
 		this.orderStatus = order.getOrderStatus();
 		this.orderDate = order.getOrderDate();
+		this.totalPrice = orderItems.stream()
+			.mapToInt(orderItem -> orderItem.getItem().getPrice() * orderItem.getCount())
+			.sum();
+
+		orderItems.stream()
+			.map(OrderItemBody::new)
+			.forEach(this.getItems()::add);
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
@@ -1,14 +1,17 @@
 package com.coffeebean.domain.order.orderItem.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.coffeebean.domain.item.entity.Item;
+import com.coffeebean.domain.item.service.ItemService;
 import com.coffeebean.domain.order.order.entity.Order;
 import com.coffeebean.domain.order.orderItem.entity.OrderItem;
 import com.coffeebean.domain.order.orderItem.repository.OrderItemRepository;
+import com.coffeebean.global.exception.DataNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,17 +20,22 @@ import lombok.RequiredArgsConstructor;
 public class OrderItemService {
 
 	private final OrderItemRepository orderItemRepository;
+	private final ItemService itemService;
 
 	@Transactional
-	public void createOrderItem(Order order, Map<Long, Integer> items) {
+	public List<OrderItem> createOrderItem(Order order, Map<Long, Integer> items) {
+		List<OrderItem> orderItems = new ArrayList<>();
 		for (Long itemId : items.keySet()) {
 			int count = items.get(itemId);
 			OrderItem orderItem = OrderItem.builder()
 				.order(order)
-				.item(Item.builder().id(itemId).build()) // 아직 Item ID 유효성 검사는 하지 않음
+				.item(itemService.getItem(itemId)
+					.orElseThrow(() -> new DataNotFoundException("주문하려는 상품이 존재하지 않습니다.")))
 				.count(count)
 				.build();
 			orderItemRepository.save(orderItem);
+			orderItems.add(orderItem);
 		}
+		return orderItems;
 	}
 }


### PR DESCRIPTION
## 🔎 작업 내용
`POST /api/v1/orders`
- 결제 완료 페이지에 필요한 데이터를 API 응답에 추가

주문자 이메일, 배송지 정보

주문 상태, 배송 상태

주문 등록 시각

주문된 상품 정보(상품명, 개별가격, 주문 수량)

결제된 총 합산 가격

  <br/>

### 변경된 응답

`POST /api/v1/orders`
```JSON
{
    "code": "201-1",
    "msg": "주문이 등록되었습니다.",
    "data": {
        "id": 23,
        "email": "notmember@exam.com",
        "deliveryAddress": {
            "city": "서울",
            "street": "원두아파트 100동 1201호",
            "zipcode": "23578"
        },
        "deliveryStatus": "READY",
        "orderStatus": "ORDER",
        "orderDate": "2025-02-23T18:35:24.311627",
        "items": [
            {
                "id": 16,
                "name": "16상품",
                "count": 2,
                "price": 26000
            },
            {
                "id": 8,
                "name": "8상품",
                "count": 3,
                "price": 18000
            }
        ],
        "totalPrice": 106000
    }
}
```

<br/>

## ➕ 이슈 링크
- #47 

<br/>

<!-- closed #47  -->