### PR TITLE
feat(54): 질문 관련 페이지 구성 + 백엔드와 연동

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/item/controller/ApiV1ItemController.java
+++ b/backend/src/main/java/com/coffeebean/domain/item/controller/ApiV1ItemController.java
@@ -4,21 +4,25 @@ import com.coffeebean.domain.item.dto.ItemDto;
 import com.coffeebean.domain.item.dto.ItemListResponseDto;
 import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.item.service.ItemService;
+import com.coffeebean.domain.question.question.dto.QuestionDto;
+import com.coffeebean.domain.question.question.service.QuestionService;
 import com.coffeebean.global.dto.RsData;
 import com.coffeebean.global.exception.ServiceException;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/items")
 public class ApiV1ItemController {
 
-    @Autowired
-    private ItemService itemService;
+    private final ItemService itemService;
+    private final QuestionService questionService;
 
 
     record AddReqBody(
@@ -111,5 +115,19 @@ public class ApiV1ItemController {
                 "'%S' 상품이 수정완료 되었습니다.".formatted(modifyItem.getName())
         );
 
+    }
+
+    // 해당 상품의 질문 목록 조회
+    @GetMapping("/{id}/questions")
+    public RsData<List<QuestionDto>> getQuestions(@RequestParam Long itemId) {
+        try {
+            // itemId에 해당하는 질문 목록 조회
+            List<QuestionDto> questions = questionService.getQuestionsByItemId(itemId).stream()
+                    .map(QuestionDto::new)
+                    .toList();
+            return new RsData<>("200-1", "질문 목록 조회가 완료되었습니다.", questions);
+        } catch (Exception e) {
+            return new RsData<>("500-1", "질문 목록을 불러오는 데 실패했습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/repository/QuestionRepository.java
@@ -17,4 +17,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
 	@EntityGraph(attributePaths = {"author", "answer"})
 	List<Question> findAll();
+
+	@EntityGraph(attributePaths = {"author", "answer"})
+    List<Question> findByItemId(Long itemId);
 }

--- a/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
+++ b/backend/src/main/java/com/coffeebean/domain/question/question/service/QuestionService.java
@@ -1,5 +1,6 @@
 package com.coffeebean.domain.question.question.service;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -60,5 +61,9 @@ public class QuestionService {
 		Question question = questionRepository.findById(questionId)
 			.orElseThrow(() -> new DataNotFoundException("존재하지 않는 질문입니다."));
 		question.deleteAnswer();
+	}
+
+	public List<Question> getQuestionsByItemId(Long itemId) {
+		return questionRepository.findByItemId(itemId);
 	}
 }

--- a/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
+++ b/backend/src/main/java/com/coffeebean/global/init/BaseInit.java
@@ -67,7 +67,10 @@ public class BaseInit {
 					itemRepository.save(Item.builder()
 						.stockQuantity(3)
 						.price(10000 + i * 1000)
-						.description(i + "상품의 설명")
+						.description("이 상품은 최고급 원두를 공수해 파는 No.1 제품입니다.<br>" +
+								"이 제품은 사상 최대로 팔렸으며 지금도 월드 레코드를 갱신해 나가는 중입니다.<br>" +
+								"상품번호는 " + i + "입니다.<br>" +
+								"상품 문의는 문의사항에서 질문해주세요" )
 						.name(i + "상품")
 						.build());
 				}
@@ -114,6 +117,15 @@ public class BaseInit {
 					.subject("상품 원산지 관련 문의입니다.")
 					.content("상품 원산지 정보가 표시되어 있지 않은데 어디인가요?")
 					.build());
+
+				long item3Id = 3L;
+				Item item3 = itemRepository.findById(item3Id).get();
+				questionRepository.save(Question.builder()
+						.item(item3)
+						.author(user)
+						.subject("상품 원산지 관련 문의입니다.")
+						.content("상품 원산지 정보가 표시되어 있지 않은데 어디인가요?")
+						.build());
 			}
 		};
 	}

--- a/frontend/src/app/items/[id]/ClientPage.tsx
+++ b/frontend/src/app/items/[id]/ClientPage.tsx
@@ -229,7 +229,7 @@ export default function ClientPage({ id }: { id: number }) {
                     key={question.id}
                     className="p-4 border rounded-lg shadow"
                   >
-                    <Link href={`/question/${question.id}`} className="block">
+                    <Link href={`/questions/${question.id}`} className="block">
                       <h2 className="text-lg font-semibold">
                         {question.subject}
                       </h2>

--- a/frontend/src/app/items/[id]/ClientPage.tsx
+++ b/frontend/src/app/items/[id]/ClientPage.tsx
@@ -18,6 +18,9 @@ export default function ClientPage({ id }: { id: number }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [quantity, setQuantity] = useState(1); // 수량 상태 관리
+  const [selectedTab, setSelectedTab] = useState<
+    "info" | "review" | "question"
+  >("info"); // 선택된 탭 상태
 
   useEffect(() => {
     setLoading(true);
@@ -121,13 +124,61 @@ export default function ClientPage({ id }: { id: number }) {
           </div>
         </div>
       </div>
-      <div className="flex flex-row gap-4 justify-center py-4">
-        <div className="p-6 rounded-2xl w-[50vw] h-[50vh] flex justify-center font-bold text-2xl ">
-          상품 정보 : {item.description}
-        </div>
-        <div className="p-6 w-[50vw] h-[50vh] flex justify-center gap-4 font-bold text-2xl ">
-          <div>리뷰</div>
-        </div>
+
+      {/* 탭 UI */}
+      <div className="flex justify-center space-x-4 py-4 border-b-2">
+        <Button
+          className={`px-6 py-2 rounded-t-lg ${
+            selectedTab === "info"
+              ? "bg-blue-500 text-white"
+              : "bg-gray-200 text-black"
+          }`}
+          onClick={() => setSelectedTab("info")}
+        >
+          상품 정보
+        </Button>
+        <Button
+          className={`px-6 py-2 rounded-t-lg ${
+            selectedTab === "review"
+              ? "bg-blue-500 text-white"
+              : "bg-gray-200 text-black"
+          }`}
+          onClick={() => setSelectedTab("review")}
+        >
+          리뷰
+        </Button>
+        <Button
+          className={`px-6 py-2 rounded-t-lg ${
+            selectedTab === "question"
+              ? "bg-blue-500 text-white"
+              : "bg-gray-200 text-black"
+          }`}
+          onClick={() => setSelectedTab("question")}
+        >
+          상품 문의
+        </Button>
+      </div>
+
+      {/* 선택된 탭에 따라 내용 표시 */}
+      <div className="p-6">
+        {selectedTab === "info" && (
+          <div className="text-2xl font-bold">
+            <h2>상품 정보</h2>
+            <p>{item.description}</p>
+          </div>
+        )}
+        {selectedTab === "review" && (
+          <div className="text-2xl font-bold">
+            <h2>리뷰</h2>
+            <p>여기에 리뷰 목록이 들어갑니다.</p>
+          </div>
+        )}
+        {selectedTab === "question" && (
+          <div className="text-2xl font-bold">
+            <h2>상품 문의</h2>
+            <p>여기에 상품 문의 목록이 들어갑니다.</p>
+          </div>
+        )}
       </div>
     </>
   );

--- a/frontend/src/app/items/[id]/ClientPage.tsx
+++ b/frontend/src/app/items/[id]/ClientPage.tsx
@@ -202,9 +202,7 @@ export default function ClientPage({ id }: { id: number }) {
         {selectedTab === "info" && (
           <div className="text-2xl h-[50vh]">
             <h2>상품 정보</h2>
-            <p>
-              <div dangerouslySetInnerHTML={{ __html: item.description }} />
-            </p>
+            <div dangerouslySetInnerHTML={{ __html: item.description }} />
           </div>
         )}
         {selectedTab === "review" && (

--- a/frontend/src/app/items/[id]/ClientPage.tsx
+++ b/frontend/src/app/items/[id]/ClientPage.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 // ItemDto 인터페이스 정의
@@ -13,6 +14,23 @@ interface ItemDto {
   description: string;
 }
 
+interface AnswerDto {
+  content: string;
+  createDate: string;
+  modifyDate: string;
+}
+
+interface QuestionDto {
+  id: number;
+  itemId: number;
+  name: string;
+  subject: string;
+  content: string;
+  createDate: string;
+  modifyDate: string;
+  answer: AnswerDto | null;
+}
+
 export default function ClientPage({ id }: { id: number }) {
   const [item, setItem] = useState<ItemDto | null>(null);
   const [loading, setLoading] = useState(true);
@@ -21,6 +39,7 @@ export default function ClientPage({ id }: { id: number }) {
   const [selectedTab, setSelectedTab] = useState<
     "info" | "review" | "question"
   >("info"); // 선택된 탭 상태
+  const [questions, setQuestions] = useState<QuestionDto[]>([]);
 
   useEffect(() => {
     setLoading(true);
@@ -41,6 +60,25 @@ export default function ClientPage({ id }: { id: number }) {
         setLoading(false);
       });
   }, [id]); // id가 변경될 때마다 실행
+
+  useEffect(() => {
+    if (selectedTab === "question") {
+      fetch(`http://localhost:8080/api/v1/items/${id}/questions?itemId=${id}`)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error("질문 목록을 불러오는 데 실패했습니다.");
+          }
+          return response.json();
+        })
+        .then((data) => {
+          setQuestions(data.data);
+        })
+        .catch((error) => {
+          console.error("Error fetching questions:", error);
+          setError("질문 목록을 불러올 수 없습니다.");
+        });
+    }
+  }, [id, selectedTab]);
 
   const increaseQuantity = () => {
     if (quantity < (item?.stockQuantity || 0)) {
@@ -128,32 +166,32 @@ export default function ClientPage({ id }: { id: number }) {
       {/* 탭 UI */}
       <div className="flex justify-center space-x-4 py-4 border-b-2">
         <Button
-          className={`px-6 py-2 rounded-t-lg ${
+          onClick={() => setSelectedTab("info")}
+          className={
             selectedTab === "info"
               ? "bg-blue-500 text-white"
               : "bg-gray-200 text-black"
-          }`}
-          onClick={() => setSelectedTab("info")}
+          }
         >
           상품 정보
         </Button>
         <Button
-          className={`px-6 py-2 rounded-t-lg ${
+          onClick={() => setSelectedTab("review")}
+          className={
             selectedTab === "review"
               ? "bg-blue-500 text-white"
               : "bg-gray-200 text-black"
-          }`}
-          onClick={() => setSelectedTab("review")}
+          }
         >
           리뷰
         </Button>
         <Button
-          className={`px-6 py-2 rounded-t-lg ${
+          onClick={() => setSelectedTab("question")}
+          className={
             selectedTab === "question"
               ? "bg-blue-500 text-white"
               : "bg-gray-200 text-black"
-          }`}
-          onClick={() => setSelectedTab("question")}
+          }
         >
           상품 문의
         </Button>
@@ -162,21 +200,67 @@ export default function ClientPage({ id }: { id: number }) {
       {/* 선택된 탭에 따라 내용 표시 */}
       <div className="p-6">
         {selectedTab === "info" && (
-          <div className="text-2xl font-bold">
+          <div className="text-2xl h-[50vh]">
             <h2>상품 정보</h2>
-            <p>{item.description}</p>
+            <p>
+              <div dangerouslySetInnerHTML={{ __html: item.description }} />
+            </p>
           </div>
         )}
         {selectedTab === "review" && (
-          <div className="text-2xl font-bold">
+          <div className="text-2xl h-[50vh]">
             <h2>리뷰</h2>
             <p>여기에 리뷰 목록이 들어갑니다.</p>
           </div>
         )}
         {selectedTab === "question" && (
-          <div className="text-2xl font-bold">
-            <h2>상품 문의</h2>
-            <p>여기에 상품 문의 목록이 들어갑니다.</p>
+          <div className="">
+            <div className="flex justify-center pb-4">
+              <Link href="/questions/new">
+                <Button className="border-2 border-blue-500 w-[100px] bg-white text-black hover:bg-gray-400 ">
+                  질문 작성
+                </Button>
+              </Link>
+            </div>
+            {questions.length > 0 ? (
+              <ul>
+                {questions.map((question) => (
+                  <li
+                    key={question.id}
+                    className="p-4 border rounded-lg shadow"
+                  >
+                    <Link href={`/question/${question.id}`} className="block">
+                      <h2 className="text-lg font-semibold">
+                        {question.subject}
+                      </h2>
+                      <p className="text-gray-600">작성자: {question.name}</p>
+                      <p className="text-sm text-gray-500">
+                        작성일: {new Date(question.createDate).toLocaleString()}
+                      </p>
+                      <p className="mt-2">{question.content}</p>
+                    </Link>
+                    {question.answer ? (
+                      <div className="mt-4 p-3 border-l-4 border-blue-500 bg-blue-50">
+                        <p className="font-semibold">답변:</p>
+                        <p>{question.answer.content}</p>
+                        <p className="text-xs text-gray-500">
+                          작성일:{" "}
+                          {new Date(
+                            question.answer.createDate
+                          ).toLocaleString()}
+                        </p>
+                      </div>
+                    ) : (
+                      <p className="mt-4 text-gray-500">
+                        아직 답변이 없습니다.
+                      </p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>등록된 질문이 없습니다.</p>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/app/questions/ClientPage.tsx
+++ b/frontend/src/app/questions/ClientPage.tsx
@@ -58,8 +58,9 @@ export default function QuestionsPage() {
         <ul className="space-y-4">
           {questions.map((question) => (
             <li key={question.id} className="p-4 border rounded-lg shadow">
-              <Link href={`/question/${question.id}`} className="block">
+              <Link href={`/questions/${question.id}`} className="block">
                 <h2 className="text-lg font-semibold">{question.subject}</h2>
+                <p className="text-gray-600">상품번호: {question.itemId}</p>
                 <p className="text-gray-600">작성자: {question.name}</p>
                 <p className="text-sm text-gray-500">
                   작성일: {new Date(question.createDate).toLocaleString()}

--- a/frontend/src/app/questions/ClientPage.tsx
+++ b/frontend/src/app/questions/ClientPage.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+interface AnswerDto {
+  content: string;
+  createDate: string;
+  modifyDate: string;
+}
+
+interface QuestionDto {
+  id: number;
+  itemId: number;
+  name: string;
+  subject: string;
+  content: string;
+  createDate: string;
+  modifyDate: string;
+  answer: AnswerDto | null;
+}
+
+export default function QuestionsPage() {
+  const [questions, setQuestions] = useState<QuestionDto[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("http://localhost:8080/api/v1/questions") // 백엔드 API 주소
+      .then((res) => res.json())
+      .then((data) => {
+        setQuestions(data.data); // RsData<List<QuestionDto>> 형태로 반환된다고 가정
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error fetching questions:", error);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return <div className="text-center mt-10">Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-5">
+      <div className="flex justify-between">
+        <h1 className="text-2xl font-bold mb-4">질문 목록</h1>
+        <Link href="/questions/new">
+          <Button className="border-2 border-blue-500 w-[100px] bg-white text-black hover:bg-gray-400 ">
+            질문 작성
+          </Button>
+        </Link>
+      </div>
+      {questions.length === 0 ? (
+        <p>질문이 없습니다.</p>
+      ) : (
+        <ul className="space-y-4">
+          {questions.map((question) => (
+            <li key={question.id} className="p-4 border rounded-lg shadow">
+              <Link href={`/question/${question.id}`} className="block">
+                <h2 className="text-lg font-semibold">{question.subject}</h2>
+                <p className="text-gray-600">작성자: {question.name}</p>
+                <p className="text-sm text-gray-500">
+                  작성일: {new Date(question.createDate).toLocaleString()}
+                </p>
+                <p className="mt-2">{question.content}</p>
+              </Link>
+              {/* {question.answer && (
+                <div className="mt-4 p-3 border-l-4 border-blue-500 bg-blue-50">
+                  <p className="font-semibold">답변:</p>
+                  <p>{question.answer.content}</p>
+                  <p className="text-xs text-gray-500">
+                    작성일:{" "}
+                    {new Date(question.answer.createDate).toLocaleString()}
+                  </p>
+                </div>
+              )} */}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/questions/[id]/ClientPage.tsx
+++ b/frontend/src/app/questions/[id]/ClientPage.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+
+interface AnswerDto {
+  content: string;
+  createDate: string;
+  modifyDate: string;
+}
+
+interface QuestionDto {
+  id: number;
+  itemId: number;
+  name: string;
+  subject: string;
+  content: string;
+  createDate: string;
+  modifyDate: string;
+  answer: AnswerDto | null;
+}
+
+export default function QuestionDetailPage() {
+  const { id } = useParams(); // URL에서 id 가져오기
+  const [question, setQuestion] = useState<QuestionDto | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+
+    fetch(`http://localhost:8080/api/v1/questions/${id}`) // 백엔드 API 호출
+      .then((res) => res.json())
+      .then((data) => {
+        setQuestion(data.data); // RsData<QuestionDto> 형식으로 반환됨
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error fetching question:", error);
+        setLoading(false);
+      });
+  }, [id]);
+
+  if (loading) {
+    return <div className="text-center mt-10">Loading...</div>;
+  }
+
+  if (!question) {
+    return (
+      <div className="text-center mt-10 text-red-500">
+        질문을 찾을 수 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-5">
+      <h1 className="text-2xl font-bold">{question.subject}</h1>
+      <p className="text-gray-600">작성자: {question.name}</p>
+      <p className="text-sm text-gray-500">
+        작성일: {new Date(question.createDate).toLocaleString()}
+      </p>
+      <div className="mt-4 p-4 border rounded-lg shadow">
+        <p>{question.content}</p>
+      </div>
+
+      {question.answer ? (
+        <div className="mt-6 p-4 border-l-4 border-green-500 bg-green-50">
+          <p className="font-semibold">답변:</p>
+          <p>{question.answer.content}</p>
+          <p className="text-xs text-gray-500">
+            작성일: {new Date(question.answer.createDate).toLocaleString()}
+          </p>
+        </div>
+      ) : (
+        <p className="mt-4 text-gray-500">아직 답변이 없습니다.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/questions/[id]/ClientPage.tsx
+++ b/frontend/src/app/questions/[id]/ClientPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation"; // useRouter 추가
 
 interface AnswerDto {
   content: string;
@@ -22,6 +22,7 @@ interface QuestionDto {
 
 export default function QuestionDetailPage() {
   const { id } = useParams(); // URL에서 id 가져오기
+  const router = useRouter(); // useRouter로 리다이렉트 처리
   const [question, setQuestion] = useState<QuestionDto | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -39,6 +40,32 @@ export default function QuestionDetailPage() {
         setLoading(false);
       });
   }, [id]);
+
+  const handleDelete = () => {
+    if (window.confirm("정말로 이 질문을 삭제하시겠습니까?")) {
+      fetch(`http://localhost:8080/api/v1/questions/${id}`, {
+        method: "DELETE", // DELETE 메서드로 요청
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          authToken: "TEMP_AUTH_TOKEN", // 인증 토큰을 여기에 넣어주세요
+        }),
+      })
+        .then((res) => {
+          if (res.ok) {
+            alert("질문이 삭제되었습니다.");
+            router.back(); // 이전 페이지로 돌아가기
+          } else {
+            alert("삭제에 실패했습니다.");
+          }
+        })
+        .catch((error) => {
+          console.error("Error deleting question:", error);
+          alert("삭제 중 오류가 발생했습니다.");
+        });
+    }
+  };
 
   if (loading) {
     return <div className="text-center mt-10">Loading...</div>;
@@ -74,6 +101,14 @@ export default function QuestionDetailPage() {
       ) : (
         <p className="mt-4 text-gray-500">아직 답변이 없습니다.</p>
       )}
+
+      {/* 삭제 버튼 추가 */}
+      <button
+        onClick={handleDelete}
+        className="mt-6 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+      >
+        질문 삭제
+      </button>
     </div>
   );
 }

--- a/frontend/src/app/questions/[id]/page.tsx
+++ b/frontend/src/app/questions/[id]/page.tsx
@@ -1,0 +1,9 @@
+import ClientPage from "./ClientPage";
+
+export default function Page() {
+  return (
+    <>
+      <ClientPage />
+    </>
+  );
+}

--- a/frontend/src/app/questions/new/ClientPage.tsx
+++ b/frontend/src/app/questions/new/ClientPage.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export default function NewQuestionPage() {
+  const router = useRouter();
+  const [itemId, setItemId] = useState("");
+  const [subject, setSubject] = useState("");
+  const [content, setContent] = useState("");
+  const [authToken, setAuthToken] = useState(""); // 사용자 인증 토큰
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const payload = { itemId: Number(itemId), subject, content, authToken };
+
+    const response = await fetch("http://localhost:8080/api/v1/questions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.ok) {
+      alert("질문이 작성되었습니다.");
+      router.push("/questions"); // 질문 목록으로 이동
+    } else {
+      const errorData = await response.json();
+      alert(`오류: ${errorData.message}`);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-5">
+      <h1 className="text-2xl font-bold mb-4">새 질문 작성</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-semibold">상품 ID:</label>
+          <input
+            type="number"
+            value={itemId}
+            onChange={(e) => setItemId(e.target.value)}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-semibold">제목:</label>
+          <input
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-semibold">내용:</label>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block font-semibold">인증 토큰:</label>
+          <input
+            type="text"
+            value={authToken}
+            onChange={(e) => setAuthToken(e.target.value)}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <Button
+          type="submit"
+          className="w-full bg-blue-500 text-white p-2 rounded"
+        >
+          질문 작성
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/questions/new/page.tsx
+++ b/frontend/src/app/questions/new/page.tsx
@@ -1,0 +1,9 @@
+import ClientPage from "./ClientPage";
+
+export default function Page() {
+  return (
+    <>
+      <ClientPage />
+    </>
+  );
+}

--- a/frontend/src/app/questions/page.tsx
+++ b/frontend/src/app/questions/page.tsx
@@ -1,0 +1,9 @@
+import ClientPage from "./ClientPage";
+
+export default function Page() {
+  return (
+    <>
+      <ClientPage />
+    </>
+  );
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 질문 목록 조회 페이지 및 연동 구현
- 질문 단건 조회 + 댓글 구현
- 질문 삭제 구현
- 상품별 질문 따로 뜨게 구현

  <br/>
- ['be/question/question-crud-5'] ['fe/item/item-page-data-24'] 이 두 부분이 필요해서 브랜치 merge 후 작업하였음

## 이미지 첨부
<img src="https://github.com/user-attachments/assets/2857f010-549d-4f31-92e0-e1ff1e4c6deb" width="50%" height="50%"/>
- 질문 목록 조회 -
 <br/> <br/>
<img src="https://github.com/user-attachments/assets/93c2b1d0-1b75-4216-bde1-a48c397b659f" width="50%" height="50%"/>
- 질문 단건 조회+댓글 -
 <br/> <br/>
<img src="https://github.com/user-attachments/assets/e52f08f7-e356-4a75-8509-9c57e4bb5429" width="50%" height="50%"/>
- 질문 삭제
-  <br/> <br/>
<img src="https://github.com/user-attachments/assets/0a9a0676-6735-4ca1-95c4-4ac86910fa14" width="50%" height="50%"/>
- 상품별 질문 목록




<br/>

## ➕ 이슈 링크
- #54 

<br/>

<!-- closed #54  -->