### PR TITLE
feat(31,32): 로그인, 로그아웃 레이아웃 및  API 연결

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/user/user/controller/UserController.java
+++ b/backend/src/main/java/com/coffeebean/domain/user/user/controller/UserController.java
@@ -10,7 +10,7 @@ import com.coffeebean.global.exception.ServiceException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -93,4 +93,22 @@ public class UserController {
 
         return new RsData<>("200-2", message, token);
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<RsData<String>> logout(HttpServletResponse response) {
+        // 쿠키 삭제 (token 이름으로 설정된 JWT 삭제)
+        ResponseCookie cookie = ResponseCookie.from("token", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0) // 쿠키 즉시 삭제
+                .sameSite("Strict")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+
+        return ResponseEntity.ok(new RsData<>("200-4", "로그아웃 성공", null));
+    }
+
+
 }

--- a/backend/src/main/java/com/coffeebean/domain/user/user/controller/UserController.java
+++ b/backend/src/main/java/com/coffeebean/domain/user/user/controller/UserController.java
@@ -10,14 +10,15 @@ import com.coffeebean.global.exception.ServiceException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
-import java.util.Optional;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/coffeebean/domain/user/user/controller/UserController.java
+++ b/backend/src/main/java/com/coffeebean/domain/user/user/controller/UserController.java
@@ -1,22 +1,34 @@
 package com.coffeebean.domain.user.user.controller;
 
+import com.coffeebean.domain.user.MyPageResponse;
 import com.coffeebean.domain.user.user.dto.EmailVerificationRequest;
 import com.coffeebean.domain.user.user.dto.SignupReqBody;
 import com.coffeebean.domain.user.user.enitity.User;
+import com.coffeebean.domain.user.user.repository.UserRepository;
 import com.coffeebean.domain.user.user.service.EmailVerificationService;
 import com.coffeebean.domain.user.user.service.UserService;
+import com.coffeebean.global.annotation.Login;
 import com.coffeebean.global.dto.RsData;
 import com.coffeebean.global.exception.ServiceException;
+import com.coffeebean.global.util.CustomUserDetails;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.buf.UEncoder;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @RestController

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 import {
   Menubar,
@@ -23,6 +24,33 @@ export default function ClinetLayout({
   fontVariable: string;
   fontClassName: string;
 }>) {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      const response = await fetch(
+        "http://localhost:8080/api/v1/users/logout",
+        {
+          method: "POST",
+          credentials: "include", // ✅ 쿠키 포함 요청
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("로그아웃 실패");
+      }
+
+      // ✅ 클라이언트에서 쿠키 삭제
+      document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+
+      alert("로그아웃 되었습니다.");
+      router.push("/"); // ✅ 기본 메인 페이지로 이동
+    } catch (error) {
+      console.error("🔴 로그아웃 중 오류 발생:", error);
+      alert("로그아웃 실패");
+    }
+  };
+
   return (
     <html lang="en" className={`${fontVariable}`}>
       <body
@@ -51,9 +79,7 @@ export default function ClinetLayout({
               </MenubarTrigger>
             </MenubarMenu>
             <MenubarMenu>
-              <MenubarTrigger>
-                <Link href="">로그아웃</Link>
-              </MenubarTrigger>
+              <MenubarTrigger onClick={handleLogout}>로그아웃</MenubarTrigger>
             </MenubarMenu>
             <MenubarMenu>
               <MenubarTrigger>My Page</MenubarTrigger>

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const API_BASE_URL = "http://localhost:8080"; // ✅ 백엔드 주소
+
+export default function AdminLoginPage() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handleLogin = async () => {
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/users/admin/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+        credentials: "include", // ✅ 쿠키 저장 (세션 유지)
+      });
+
+      if (!response.ok) {
+        const errorMsg = await response.text();
+        console.error(`🔴 로그인 실패 (${response.status}):`, errorMsg);
+        throw new Error(errorMsg);
+      }
+
+      alert("관리자 로그인 성공! 🎉");
+      router.push("/admin"); // ✅ 로그인 후 관리자 페이지로 이동
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "알 수 없는 오류 발생");
+      console.error("🔴 요청 중 오류 발생:", err);
+    }
+  };
+
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-gray-100">
+      <Card className="w-full max-w-md bg-white rounded-lg shadow-md p-6">
+        <CardHeader>
+          <CardTitle className="text-center text-xl font-bold">
+            관리자 로그인
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <p className="text-red-500 text-sm text-center mb-4">{error}</p>
+          )}
+          <div className="space-y-4">
+            <Input
+              type="text"
+              placeholder="관리자 아이디"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="w-full"
+            />
+            <Input
+              type="password"
+              placeholder="비밀번호"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full"
+            />
+            <Button
+              onClick={handleLogin}
+              className="w-full bg-red-600 hover:bg-red-700 text-white font-semibold"
+            >
+              로그인
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/app/user/login/page.tsx
+++ b/frontend/src/app/user/login/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import Link from "next/link";
+
+const API_BASE_URL = "http://localhost:8080"; // 백엔드 API 주소
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const handleLogin = async () => {
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/users/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+        credentials: "include", // ✅ 로그인 후 쿠키 자동 저장 (JWT 포함)
+      });
+
+      if (!response.ok) {
+        const errorMsg = await response.text();
+        console.error(`🔴 오류 발생 (${response.status}):`, errorMsg);
+        throw new Error(errorMsg);
+      }
+
+      const data = await response.json();
+      alert(`${data.msg}`); // ✅ 로그인 성공 메시지 출력
+      router.push("/"); // ✅ 홈으로 이동
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다."
+      );
+      console.error("🔴 로그인 요청 중 예외 발생:", err);
+    }
+  };
+
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-gray-100">
+      <Card className="w-full max-w-md bg-white rounded-lg shadow-md p-6">
+        <CardHeader>
+          <CardTitle className="text-center text-xl font-bold">
+            로그인
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <p className="text-red-500 text-sm text-center mb-4">{error}</p>
+          )}
+          <div className="space-y-4">
+            <Input
+              type="email"
+              placeholder="이메일"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full"
+            />
+            <Input
+              type="password"
+              placeholder="비밀번호"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full"
+            />
+            <Button
+              onClick={handleLogin}
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold"
+            >
+              로그인
+            </Button>
+          </div>
+          <p className="text-sm text-center mt-4">
+            계정이 없으신가요?{" "}
+            <Link href="/user/signup" className="text-blue-500">
+              회원가입
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔎 작업 내용
### 로그인
- 레이아웃 구현
- 서버 API와 연결
- 토큰 쿠키로 웹 자동 저장

### 관리자 로그인
- 레이아웃 구현(http://localhost:3000/admin/login)
- 서버 API 연결

### 로그아웃
- 레이아웃 기능 구현
- 서버 API와 연결(쿠키 삭제 요청)

  <br/>

## 이미지 첨부
### 로그인 레이아웃
![image](https://github.com/user-attachments/assets/daf67dee-2fd4-4d84-9cd4-ca68747ceeec)

로그인 성공
![image](https://github.com/user-attachments/assets/8db27997-e157-4d18-a5ac-b7e1dfc0ef56)

토큰 확인
![image](https://github.com/user-attachments/assets/09922f2a-ab4c-4294-abeb-2f5612331224)

---

### 관리자 로그인 레이아웃
![image](https://github.com/user-attachments/assets/2a9f5e41-e560-4665-8adf-114fecb4d170)

관리자 로그인 성공 창
![image](https://github.com/user-attachments/assets/0407a2bd-343e-42c4-b101-5b21981a2600)

로그인 후 관리자 페이지 이동
![image](https://github.com/user-attachments/assets/ff1832da-115b-416e-bf5c-0397675d60c9)

토큰 확인
![image](https://github.com/user-attachments/assets/ba1b71f4-8f36-43e6-80be-c903bb6b1398)

---

### 로그아웃 
로그아웃 버튼 클릭 시
![image](https://github.com/user-attachments/assets/68d8aeec-157c-4aee-8ede-48667163c656)

쿠키 자동 삭제
![image](https://github.com/user-attachments/assets/14a5883c-9608-4c51-894c-4787f25c832b)

메인 페이지 이동(관리자/일반 회원 동일)
![image](https://github.com/user-attachments/assets/25663d34-a125-47fc-a366-6a78effad7cb)


<br/>

## ➕ 이슈 링크
#31 
#32 

<br/>

<!-- closed #번호 -->