### PR TITLE
Refactor(65): JWT 필터 오류 처리 리팩토링 / JWT 필터 적용 범위 제한

### DIFF
--- a/backend/src/main/java/com/coffeebean/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/coffeebean/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.coffeebean.global.exception;
 
 import com.coffeebean.global.app.AppConfig;
 import com.coffeebean.global.dto.RsData;
+import io.jsonwebtoken.JwtException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -56,24 +57,26 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DataNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleDataNotFound(DataNotFoundException exception) {
-        ErrorResponse errorResponse = ErrorResponse.of(
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(
                 "DATA_NOT_FOUND", exception.getMessage()
-        );
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+        ));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
-        ErrorResponse errorResponse = ErrorResponse.of("INVALID_STATUS",
-                exception.getMessage());
-        return ResponseEntity.badRequest().body(errorResponse);
+        return ResponseEntity.badRequest().body(ErrorResponse.of("INVALID_STATUS",
+                exception.getMessage()));
     }
 
     @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<ErrorResponse> IllegalState(IllegalStateException exception) {
-        ErrorResponse errorResponse = ErrorResponse.of("INVALID_STATE",
-                exception.getMessage());
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    public ResponseEntity<ErrorResponse> handleIllegalState(IllegalStateException exception) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of("INVALID_STATE",
+                exception.getMessage()));
+    }
+
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<ErrorResponse> handleSecurityException(SecurityException exception) {
+        return ResponseEntity.status(401).body(ErrorResponse.of("INVALID_TOKEN", exception.getMessage()));
     }
 
 

--- a/backend/src/main/java/com/coffeebean/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/coffeebean/global/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.coffeebean.domain.user.user.repository.UserRepository;
 import java.util.Arrays;
 
 import com.coffeebean.global.app.AppConfig;
+import com.coffeebean.global.util.JwtAuthenticationFilterFromCookie;
 import com.coffeebean.global.util.JwtAuthenticationFilterFromHeader;
 import com.coffeebean.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -39,13 +40,15 @@ public class SecurityConfig {
                                 .requestMatchers("/h2-console/**", "/api/v1/user/admin/login").permitAll()
                                 // "/api/v1/user/admin/**" 경로는 관리자만 접근 가능
                                 .requestMatchers("/api/v1/user/admin/**").hasAuthority("admin")
-                                .requestMatchers("/api/my/home").authenticated()
+                                .requestMatchers("/api/my/home").authenticated() // 마이 페이지는 인증 받은 회원만 접근
+                                .requestMatchers("/api/reviews/**").authenticated() // 리뷰 페이지는 인증 받은 회원만 접근
+                                .requestMatchers("/api/point/history").authenticated()
                                 // 그 외의 모든 경로는 인증 없이 접근 가능
                                 .anyRequest().permitAll()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                // .addFilterBefore(new JwtAuthenticationFilterFromCookie(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new JwtAuthenticationFilterFromHeader(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilterFromCookie(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class)
+                //.addFilterBefore(new JwtAuthenticationFilterFromHeader(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class)
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(
                                 XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))

--- a/backend/src/main/java/com/coffeebean/global/util/JwtUtil.java
+++ b/backend/src/main/java/com/coffeebean/global/util/JwtUtil.java
@@ -82,6 +82,8 @@ public class JwtUtil {
         if (request.getCookies() != null) {
             Arrays.stream(request.getCookies())
                     .forEach(cookie -> System.out.println("Cookie Name: " + cookie.getName() + ", Value: " + cookie.getValue()));
+        } else {
+            throw new SecurityException("로그인이 필요합니다.");
         }
 
         return Arrays.stream(cookies).filter(cookie -> "token".equals(cookie.getName()))

--- a/backend/src/test/java/com/coffeebean/domain/review/review/service/ReviewServiceIntegrationTest.java
+++ b/backend/src/test/java/com/coffeebean/domain/review/review/service/ReviewServiceIntegrationTest.java
@@ -115,7 +115,7 @@ public class ReviewServiceIntegrationTest {
         String email = "test@example.com";
         
         //when
-        List<ReviewableOrderItemDto> reviewableOrderItems = reviewService.getReviewableOrderItems(email);
+        List<ReviewableOrderItemDto> reviewableOrderItems = reviewService.getPendingReviews(email);
 
         //then
         assertThat(reviewableOrderItems.size()).isEqualTo(1);
@@ -125,11 +125,12 @@ public class ReviewServiceIntegrationTest {
     @Test
     void 리뷰_수정() throws Exception {
         //given
+        Long orderItemId = 1L;
         Long reviewId = 1L;
         String newContent = "수정된 내용입니다.";
         int newRating = 4;
 
-        reviewService.writeReivew(1L, "기존 내용입니다.", 3);
+        reviewService.writeReivew(orderItemId, "기존 내용입니다.", 3);
 
         //when
         reviewService.modifyReview(reviewId, newContent, newRating);


### PR DESCRIPTION

## 🔎 작업 내용

- JWT 필터 오류 처리 리팩토링
- JWT 필터 적용 범위 제한

✅ login에서 쿠키 저장 확인
<img width="1077" alt="스크린샷 2025-02-24 오후 1 48 19" src="https://github.com/user-attachments/assets/9032f05e-eeab-4425-8186-4dd3b6be48e9" />

✅ 마이 페이지에서 쿠키 확인 후 입장
<img width="1089" alt="스크린샷 2025-02-24 오후 1 48 25" src="https://github.com/user-attachments/assets/a2492deb-1f54-44ec-9f05-e04224311093" />

<img width="554" alt="스크린샷 2025-02-24 오후 1 48 29" src="https://github.com/user-attachments/assets/fbbf3241-d0d9-4ba2-9f2d-9bdcd0cfc4be" />

✅ 마이 페이지, 리뷰 페이지 제외하고는 별도의 토큰이 없어도 입장 가능
<img width="1082" alt="스크린샷 2025-02-24 오후 1 49 07" src="https://github.com/user-attachments/assets/b6919828-9f46-44d1-aa75-ea49c0010b66" />
<img width="897" alt="스크린샷 2025-02-24 오후 1 49 12" src="https://github.com/user-attachments/assets/837e8a96-e6fa-4488-9d98-727341342848" />

## ➕ 이슈 링크
- [REFACTOR] JWT 필터 오류 처리 리팩토링 / JWT 필터 적용 범위 제한 #65 (https://github.com/prgrms-be-devcourse/NBE4-5-1-Team07/issues/65)]