### PR TITLE
feat(73): 상품 재고 수량과 관련된 기능 적용(장바구니, 결제, 주문 페이지)

### DIFF
--- a/backend/src/main/java/com/coffeebean/domain/cart/cart/entity/Cart.java
+++ b/backend/src/main/java/com/coffeebean/domain/cart/cart/entity/Cart.java
@@ -1,8 +1,11 @@
 package com.coffeebean.domain.cart.cart.entity;
 
 import com.coffeebean.domain.cart.cartItem.entity.CartItem;
+
 import jakarta.persistence.*;
 
+import com.coffeebean.domain.item.entity.Item;
+import com.coffeebean.domain.order.orderItem.entity.OrderItem;
 import com.coffeebean.domain.user.user.enitity.User;
 
 import lombok.AccessLevel;
@@ -36,5 +39,9 @@ public class Cart {
 
 	public void deleteAllCartItems() {
 		cartItems.clear();
+	}
+
+	public void deleteItems(List<Item> items) {
+		cartItems.removeIf(cartItem -> items.contains(cartItem.getItem()));
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/item/entity/Item.java
+++ b/backend/src/main/java/com/coffeebean/domain/item/entity/Item.java
@@ -35,7 +35,7 @@ public class Item {
 
 	public void reduceStock(int count) {
 		if (stockQuantity < count) {
-			throw new ServiceException("400-1", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
+			throw new ServiceException("400-3", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
 		}
 		stockQuantity -= count;
 	}

--- a/backend/src/main/java/com/coffeebean/domain/item/entity/Item.java
+++ b/backend/src/main/java/com/coffeebean/domain/item/entity/Item.java
@@ -1,5 +1,7 @@
 package com.coffeebean.domain.item.entity;
 
+import com.coffeebean.global.exception.ServiceException;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,4 +32,11 @@ public class Item {
 	@Lob
 	@Column(columnDefinition = "TEXT")
 	private String description;    // 상품 설명
+
+	public void reduceStock(int count) {
+		if (stockQuantity < count) {
+			throw new ServiceException("400-1", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
+		}
+		stockQuantity -= count;
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/item/service/ItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/item/service/ItemService.java
@@ -1,12 +1,17 @@
 package com.coffeebean.domain.item.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.item.repository.ItemRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import com.coffeebean.global.exception.DataNotFoundException;
 
-import java.util.List;
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -59,4 +64,19 @@ public class ItemService {
         item.setStockQuantity(newStockQuntity);
         itemRepository.save(item);
     }
+
+    @Transactional(readOnly = true)
+	public boolean isStockSufficient(Map<Long, Integer> items) {
+        for (Long itemId : items.keySet()) {
+            int count = items.get(itemId);
+            int quantity = itemRepository.findById(itemId)
+                .orElseThrow(() -> new DataNotFoundException("존재하지 않는 상품이 포함되었습니다."))
+                .getStockQuantity();
+
+            if (quantity < count) {
+                return false;
+            }
+        }
+        return true;
+	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.coffeebean.domain.item.service.ItemService;
 import com.coffeebean.domain.order.order.dto.OrderCreateRequest;
 import com.coffeebean.domain.order.order.dto.OrderCreateResponse;
 import com.coffeebean.domain.order.order.entity.Order;
@@ -16,6 +17,7 @@ import com.coffeebean.domain.order.orderItem.service.OrderItemService;
 import com.coffeebean.domain.user.user.enitity.User;
 import com.coffeebean.domain.user.user.service.UserService;
 import com.coffeebean.global.dto.RsData;
+import com.coffeebean.global.exception.ServiceException;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,10 +30,16 @@ public class ApiV1OrderController {
 	private final OrderService orderService;
 	private final OrderItemService orderItemService;
 	private final UserService userService;
+	private final ItemService itemService;
 
 	@PostMapping
 	public RsData<OrderCreateResponse> createOrder(@RequestBody @Valid OrderCreateRequest orderCreateRequest) {
 		String email = orderCreateRequest.getEmail();
+
+		// 재고 부족 시 주문 등록 실패
+		if (!itemService.isStockSufficient(orderCreateRequest.getItems())) {
+			throw new ServiceException("400-1", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
+		}
 
 		// 회원이 주문을 등록하는 경우
 		if (orderCreateRequest.getAuthToken() != null) {

--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -38,7 +38,7 @@ public class ApiV1OrderController {
 
 		// 재고 부족 시 주문 등록 실패
 		if (!itemService.isStockSufficient(orderCreateRequest.getItems())) {
-			throw new ServiceException("400-1", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
+			throw new ServiceException("400-3", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
 		}
 
 		// 회원이 주문을 등록하는 경우

--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -14,8 +14,6 @@ import com.coffeebean.domain.order.order.entity.Order;
 import com.coffeebean.domain.order.order.service.OrderService;
 import com.coffeebean.domain.order.orderItem.entity.OrderItem;
 import com.coffeebean.domain.order.orderItem.service.OrderItemService;
-import com.coffeebean.domain.user.user.enitity.User;
-import com.coffeebean.domain.user.user.service.UserService;
 import com.coffeebean.global.dto.RsData;
 import com.coffeebean.global.exception.ServiceException;
 
@@ -29,7 +27,6 @@ public class ApiV1OrderController {
 
 	private final OrderService orderService;
 	private final OrderItemService orderItemService;
-	private final UserService userService;
 	private final ItemService itemService;
 
 	@PostMapping
@@ -41,12 +38,6 @@ public class ApiV1OrderController {
 			throw new ServiceException("400-3", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
 		}
 
-		// 회원이 주문을 등록하는 경우
-		if (orderCreateRequest.getAuthToken() != null) {
-			User actor = userService.getUserByAuthToken(orderCreateRequest.getAuthToken());
-			email = actor.getEmail();
-		}
-
 		// Order 생성
 		Order order = orderService.createOrder(email,
 			orderCreateRequest.getAddress().getCity(),
@@ -54,8 +45,7 @@ public class ApiV1OrderController {
 			orderCreateRequest.getAddress().getZipcode());
 
 		// Order의 세부 상품 항목들 OderItem 저장
-		List<OrderItem> orderItems = orderItemService.createOrderItem(order, orderCreateRequest.getItems());
-
+		List<OrderItem> orderItems = orderItemService.createOrderItem(order, orderCreateRequest.getItems(), email, orderCreateRequest.getCartOrder());
 		return new RsData<>(
 			"201-1",
 			"주문이 등록되었습니다.",

--- a/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/controller/ApiV1OrderController.java
@@ -38,6 +38,11 @@ public class ApiV1OrderController {
 			throw new ServiceException("400-3", "재고가 충분하지 않습니다. 상품 수량을 확인하세요.");
 		}
 
+		// 주문에 상품이 하나도 포함되어 있지 않으면 실패
+		if (orderCreateRequest.getItems().isEmpty()) {
+			throw new ServiceException("400-4", "주문에 상품이 추가되지 않았습니다. 먼저 상품을 추가하세요.");
+		}
+
 		// Order 생성
 		Order order = orderService.createOrder(email,
 			orderCreateRequest.getAddress().getCity(),

--- a/backend/src/main/java/com/coffeebean/domain/order/order/dto/OrderCreateRequest.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/order/dto/OrderCreateRequest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -19,26 +21,27 @@ public class OrderCreateRequest {
 	private AddressBody address;
 	@NotBlank(message = "이메일은 필수입니다.") @Email(message = "잘못된 이메일 형식입니다.")
 	private String email;
-	private String authToken;
+	@JsonProperty("cartOrder")
+	private Boolean cartOrder;
 
 	@Getter(AccessLevel.PUBLIC)
 	@Setter
 	static class OrderItemBody {
 		@NotNull(message = "상품 ID는 필수입니다.")
-		protected Long id;
+		private Long id;
 		@Min(value = 1, message = "수량은 1개 이상입니다.")
-		protected int count;
+		private int count;
 	}
 
 	@Getter(AccessLevel.PUBLIC)
 	@Setter
 	public static class AddressBody {
 		@NotBlank(message = "배송지 주소 도시명은 필수입니다.")
-		protected String city;
+		private String city;
 		@NotBlank(message = "배송지 주소 상세주소는 필수입니다.")
-		protected String street;
+		private String street;
 		@NotBlank(message = "배송지 주소 우편번호는 필수입니다.")
-		protected String zipcode;
+		private String zipcode;
 	}
 
 	public Map<Long, Integer> getItems() {

--- a/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
@@ -7,7 +7,8 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.coffeebean.domain.item.service.ItemService;
+import com.coffeebean.domain.item.entity.Item;
+import com.coffeebean.domain.item.repository.ItemRepository;
 import com.coffeebean.domain.order.order.entity.Order;
 import com.coffeebean.domain.order.orderItem.entity.OrderItem;
 import com.coffeebean.domain.order.orderItem.repository.OrderItemRepository;
@@ -20,20 +21,24 @@ import lombok.RequiredArgsConstructor;
 public class OrderItemService {
 
 	private final OrderItemRepository orderItemRepository;
-	private final ItemService itemService;
+	private final ItemRepository itemRepository;
 
 	@Transactional
 	public List<OrderItem> createOrderItem(Order order, Map<Long, Integer> items) {
 		List<OrderItem> orderItems = new ArrayList<>();
 		for (Long itemId : items.keySet()) {
 			int count = items.get(itemId);
+			Item item = itemRepository.findById(itemId)
+				.orElseThrow(() -> new DataNotFoundException("주문하려는 상품이 존재하지 않습니다."));
+
 			OrderItem orderItem = OrderItem.builder()
 				.order(order)
-				.item(itemService.getItem(itemId)
-					.orElseThrow(() -> new DataNotFoundException("주문하려는 상품이 존재하지 않습니다.")))
+				.item(item)
 				.count(count)
 				.build();
+
 			orderItemRepository.save(orderItem);
+			item.reduceStock(count);
 			orderItems.add(orderItem);
 		}
 		return orderItems;

--- a/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
@@ -3,15 +3,24 @@ package com.coffeebean.domain.order.orderItem.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.coffeebean.domain.cart.cart.entity.Cart;
+import com.coffeebean.domain.cart.cart.repository.CartRepository;
+import com.coffeebean.domain.cart.cart.service.CartService;
+import com.coffeebean.domain.cart.cartItem.repository.CartItemRepository;
 import com.coffeebean.domain.item.entity.Item;
 import com.coffeebean.domain.item.repository.ItemRepository;
 import com.coffeebean.domain.order.order.entity.Order;
 import com.coffeebean.domain.order.orderItem.entity.OrderItem;
 import com.coffeebean.domain.order.orderItem.repository.OrderItemRepository;
+import com.coffeebean.domain.user.user.enitity.User;
+import com.coffeebean.domain.user.user.repository.UserRepository;
+import com.coffeebean.domain.user.user.service.UserService;
 import com.coffeebean.global.exception.DataNotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -22,10 +31,13 @@ public class OrderItemService {
 
 	private final OrderItemRepository orderItemRepository;
 	private final ItemRepository itemRepository;
+	private final UserRepository userRepository;
+	private final CartService cartService;
 
 	@Transactional
-	public List<OrderItem> createOrderItem(Order order, Map<Long, Integer> items) {
+	public List<OrderItem> createOrderItem(Order order, Map<Long, Integer> items, String email, boolean isCartOrder) {
 		List<OrderItem> orderItems = new ArrayList<>();
+
 		for (Long itemId : items.keySet()) {
 			int count = items.get(itemId);
 			Item item = itemRepository.findById(itemId)
@@ -41,6 +53,15 @@ public class OrderItemService {
 			item.reduceStock(count);
 			orderItems.add(orderItem);
 		}
+
+		Optional<User> opActor = userRepository.findByEmail(email);
+		if (isCartOrder && opActor.isPresent()) {
+			Cart cart = cartService.getMyCart(opActor.get());
+			cart.deleteItems(orderItems.stream()
+				.map(OrderItem::getItem)
+				.collect(Collectors.toList()));
+		}
+
 		return orderItems;
 	}
 }

--- a/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
+++ b/backend/src/main/java/com/coffeebean/domain/order/orderItem/service/OrderItemService.java
@@ -47,6 +47,7 @@ public class OrderItemService {
 				.order(order)
 				.item(item)
 				.count(count)
+				.orderPrice(item.getPrice())
 				.build();
 
 			orderItemRepository.save(orderItem);

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -43,6 +43,9 @@ export default function ClinetLayout({
       // ✅ 클라이언트에서 쿠키 삭제
       document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 
+      // 장바구니 선택 데이터 삭제
+      localStorage.removeItem("selectedCartItems");
+
       alert("로그아웃 되었습니다.");
       router.push("/"); // ✅ 기본 메인 페이지로 이동
     } catch (error) {

--- a/frontend/src/app/cart/ClientPage.tsx
+++ b/frontend/src/app/cart/ClientPage.tsx
@@ -78,6 +78,7 @@ export default function Cart() {
       selectedItems.includes(item.id)
     );
     localStorage.setItem("checkoutItems", JSON.stringify(selectedProducts));
+    localStorage.setItem("cartOrder", "true");
 
     router.push("/orders/payment");
   };

--- a/frontend/src/app/items/[id]/ClientPage.tsx
+++ b/frontend/src/app/items/[id]/ClientPage.tsx
@@ -177,6 +177,7 @@ export default function ClientPage({ id }: { id: number }) {
     ];
 
     localStorage.setItem("checkoutItems", JSON.stringify(checkoutItems));
+    localStorage.removeItem("cartOrder");
 
     // 결제 페이지로 이동
     router.push("/orders/payment");

--- a/frontend/src/app/orders/payment/ClientPage.tsx
+++ b/frontend/src/app/orders/payment/ClientPage.tsx
@@ -123,6 +123,7 @@ export default function PaymentPage() {
         alert(result.msg);
       } else if (response.ok) {
         alert("결제가 완료되었습니다.");
+        localStorage.removeItem("selectedCartItems");
         sessionStorage.setItem("orderData", JSON.stringify(result.data));
         router.push(`/orders/complete`);
       } else {

--- a/frontend/src/app/orders/payment/ClientPage.tsx
+++ b/frontend/src/app/orders/payment/ClientPage.tsx
@@ -11,6 +11,7 @@ interface Product {
 }
 
 export default function PaymentPage() {
+  const [cartOrder, setCartOrder] = useState<boolean>(false);
   const [products, setProducts] = useState<Product[]>([]);
   const [totalPrice, setTotalPrice] = useState(0);
   const [email, setEmail] = useState("");
@@ -23,9 +24,13 @@ export default function PaymentPage() {
   // localStorage에서 데이터 가져오기
   useEffect(() => {
     const storedProducts = localStorage.getItem("checkoutItems");
+    const storedCartOrder = localStorage.getItem("cartOrder");
 
     if (storedProducts) {
       setProducts(JSON.parse(storedProducts));
+    }
+    if (storedCartOrder && storedCartOrder === "true") {
+      setCartOrder(true);
     }
   }, []);
 
@@ -66,6 +71,7 @@ export default function PaymentPage() {
     }
 
     const orderData = {
+      cartOrder: cartOrder,
       email,
       address: { city, street, zipcode },
       items: products.map(({ id, quantity }) => ({

--- a/frontend/src/app/orders/payment/ClientPage.tsx
+++ b/frontend/src/app/orders/payment/ClientPage.tsx
@@ -85,7 +85,9 @@ export default function PaymentPage() {
       });
 
       const result = await response.json();
-      if (response.ok) {
+      if (result.code === "400-3") {
+        alert(result.msg);
+      } else if (response.ok) {
         alert("결제가 완료되었습니다.");
 
         // 주문 데이터를 sessionStorage에 저장

--- a/frontend/src/app/orders/payment/ClientPage.tsx
+++ b/frontend/src/app/orders/payment/ClientPage.tsx
@@ -18,7 +18,8 @@ export default function PaymentPage() {
   const [city, setCity] = useState("");
   const [street, setStreet] = useState("");
   const [zipcode, setZipcode] = useState("");
-  const [isMember, setIsMember] = useState(false); // 회원 여부 추가
+  const [isMember, setIsMember] = useState(false);
+  const [stockMap, setStockMap] = useState<{ [key: number]: number }>({}); // 재고량 저장
   const router = useRouter();
 
   // localStorage에서 데이터 가져오기
@@ -43,11 +44,40 @@ export default function PaymentPage() {
     setTotalPrice(total);
   }, [products]);
 
+  // 각 상품의 재고량 조회
+  useEffect(() => {
+    const fetchStock = async () => {
+      const stockData: { [key: number]: number } = {};
+      await Promise.all(
+        products.map(async (product) => {
+          try {
+            const res = await fetch(
+              `http://localhost:8080/api/v1/items/${product.id}`
+            );
+            const data = await res.json();
+            if (res.ok) {
+              stockData[product.id] = data.data.stockQuantity;
+            } else {
+              stockData[product.id] = 0; // 오류 발생 시 기본값 0 설정
+            }
+          } catch (error) {
+            stockData[product.id] = 0;
+          }
+        })
+      );
+      setStockMap(stockData);
+    };
+
+    if (products.length > 0) {
+      fetchStock();
+    }
+  }, [products]);
+
   // 회원 정보 가져오기
   useEffect(() => {
     fetch("http://localhost:8080/api/my/info", {
       method: "GET",
-      credentials: "include", // 쿠키 인증 정보 포함
+      credentials: "include",
     })
       .then((res) => res.json())
       .then((data) => {
@@ -56,12 +86,10 @@ export default function PaymentPage() {
           setCity(data.data.address.city);
           setStreet(data.data.address.street);
           setZipcode(data.data.address.zipcode);
-          setIsMember(true); // 회원이면 true 설정
+          setIsMember(true);
         }
       })
-      .catch(() => {
-        // 비회원이면 입력칸 유지 (isMember = false)
-      });
+      .catch(() => {});
   }, []);
 
   const handlePayment = async () => {
@@ -95,11 +123,7 @@ export default function PaymentPage() {
         alert(result.msg);
       } else if (response.ok) {
         alert("결제가 완료되었습니다.");
-
-        // 주문 데이터를 sessionStorage에 저장
         sessionStorage.setItem("orderData", JSON.stringify(result.data));
-
-        // 결제 완료 페이지로 리디렉션
         router.push(`/orders/complete`);
       } else {
         alert(result.msg || "결제 실패");
@@ -116,15 +140,30 @@ export default function PaymentPage() {
       {/* 상품 목록 */}
       <div className="mb-6">
         <h3 className="text-xl font-semibold mb-2">상품 목록</h3>
-        {products.map((product) => (
-          <div key={product.id} className="flex justify-between p-2 border-b">
-            <span>{product.name}</span>
-            <span>
-              {product.price.toLocaleString()}원{" "}
-              <span className="text-gray-500">({product.quantity}개)</span>
-            </span>
-          </div>
-        ))}
+        {products.map((product) => {
+          const stock = stockMap[product.id] ?? 0; // 기본값 0
+          const isOutOfStock = product.quantity > stock; // 초과 여부
+
+          return (
+            <div key={product.id} className="flex justify-between p-2 border-b">
+              <span>{product.name}</span>
+              <span>
+                {product.price.toLocaleString()}원{" "}
+                <span className="text-gray-500">({product.quantity}개)</span>
+                {"   "}
+                <span
+                  className={
+                    isOutOfStock
+                      ? "text-red-600 font-bold text-sm"
+                      : "text-gray-600 text-sm"
+                  }
+                >
+                  {stock}개 남음
+                </span>
+              </span>
+            </div>
+          );
+        })}
       </div>
 
       {/* 총 가격 */}
@@ -141,7 +180,7 @@ export default function PaymentPage() {
           onChange={(e) => setEmail(e.target.value)}
           className="w-full p-2 border rounded"
           placeholder="이메일 입력"
-          disabled={isMember} // 회원이면 수정 불가
+          disabled={isMember}
         />
       </div>
 

--- a/frontend/src/app/user/login/page.tsx
+++ b/frontend/src/app/user/login/page.tsx
@@ -33,6 +33,10 @@ export default function LoginPage() {
       }
 
       const data = await response.json();
+
+      // 장바구니 선택 데이터 삭제
+      localStorage.removeItem("selectedCartItems");
+
       alert(`${data.msg}`); // ✅ 로그인 성공 메시지 출력
       router.push("/"); // ✅ 홈으로 이동
     } catch (err) {


### PR DESCRIPTION
## 🔎 작업 내용

### **주문 등록**

- 주문 등록 완료(결제완료) 시 **상품 재고량** 주문량만큼 감소
- **상품 데이터가 비어 있는 주문** 등록 요청에 대해 실패 응답, 알림창
- **재고보다 많은 수량을 주문**하는 요청에 대해 실패 응답, 알림창

### **장바구니**

- 회원이 장바구니를 통해 주문한 경우, **장바구니에서 주문이 완료된 상품은 제거**됨
- 제품 상세 페이지에서 바로 구매를 한 경우, 장바구니에 해당 상품이 있더라도 제거되지 않음

### **결제**
- 결제 페이지에 주문하려는 상품의 재고 수 표시(주문량이 재고수보다 많으면 빨간색으로 표시)

  <br/>

## 특이사항
- 로그인/로그아웃 시 브라우저의 localStorage에 저장된 장바구니의 선택된 아이템이 같이 저장되어버리는 오류 해결을 위해 로그인/로그아웃 시 localStorage의 해당 저장값 초기화하는 코드 추가 (front)

## 이미지 첨부
**로그인한 회원이 장바구니를 통해 상품을 주문 등록한 경우 장바구니에서 해당 상품이 삭제됨. 제품 상세 페이지에서 바로구매한 경우엔 삭제하지 않음**
<img width="790" alt="스크린샷 2025-02-25 오전 1 25 50" src="https://github.com/user-attachments/assets/f2788f55-89ca-41cb-a1b9-896de81bfcf3" />
<img width="786" alt="스크린샷 2025-02-25 오전 1 26 02" src="https://github.com/user-attachments/assets/47369987-c615-45d3-b095-986b8a301dbc" />
<img width="782" alt="스크린샷 2025-02-25 오전 1 28 29" src="https://github.com/user-attachments/assets/29273ba1-293b-42ae-af4e-8d9fa70ac685" />

**재고 수량보다 많은 상품을 주문 시도 시 빨간색으로 남은 재고 수량이 표시되고, 결제 진행 시 실패함**
<img width="782" alt="스크린샷 2025-02-25 오전 1 28 45" src="https://github.com/user-attachments/assets/809d4b9a-4607-4906-a0e6-86fbc7cb4f50" />



<br/>

## ➕ 이슈 링크
- #73 

<br/>

<!-- closed #73  -->